### PR TITLE
unbreak console output by ensuring actual text output

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -55,7 +55,7 @@ define letsencrypt::certonly (
   validate_array($environment)
   validate_bool($manage_cron)
 
-  $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
+  $command_start = "${letsencrypt_command} --text --agree-tos certonly -a ${plugin} "
   $command_domains = $plugin ? {
     'webroot' => inline_template('<%= @domains.zip(@webroot_paths).map { |domain| "#{"--webroot-path #{domain[1]} " if domain[1]}-d #{domain[0]}"}.join(" ") %>'),
     default   => inline_template('-d <%= @domains.join(" -d ")%>'),

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -8,19 +8,19 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_creates '/etc/letsencrypt/live/foo.example.com/cert.pem' }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a standalone -d foo.example.com' }
       end
 
       context 'with multiple domains' do
         let(:title) { 'foo' }
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos certonly -a standalone -d foo.example.com -d bar.example.com' }
       end
 
       context 'with custom command' do
         let(:title) { 'foo.example.com' }
         let(:params) { { letsencrypt_command: '/usr/lib/letsencrypt/letsencrypt-auto' } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto --agree-tos certonly -a standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto --text --agree-tos certonly -a standalone -d foo.example.com' }
       end
 
       context 'with webroot plugin' do
@@ -29,7 +29,7 @@ describe 'letsencrypt::certonly' do
           { plugin: 'webroot',
             webroot_paths: ['/var/www/foo'] }
         end
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com' }
       end
 
       context 'with webroot plugin and multiple domains' do
@@ -39,7 +39,7 @@ describe 'letsencrypt::certonly' do
             plugin: 'webroot',
             webroot_paths: ['/var/www/foo', '/var/www/bar'] }
         end
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
       end
 
       context 'with webroot plugin, one webroot, and multiple domains' do
@@ -49,7 +49,7 @@ describe 'letsencrypt::certonly' do
             plugin: 'webroot',
             webroot_paths: ['/var/www/foo'] }
         end
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com -d bar.example.com' }
       end
 
       context 'with webroot plugin and no webroot_paths' do
@@ -61,7 +61,7 @@ describe 'letsencrypt::certonly' do
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a apache -d foo.example.com' }
       end
 
       context 'with custom plugin and manage cron' do
@@ -70,7 +70,7 @@ describe 'letsencrypt::certonly' do
           { plugin: 'apache',
             manage_cron: true }
         end
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -81,7 +81,7 @@ describe 'letsencrypt::certonly' do
             cron_before_command: 'echo before',
             cron_success_command: 'echo success' }
         end
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '(echo before) && letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)' }
       end
 
       context 'with invalid plugin' do
@@ -93,7 +93,7 @@ describe 'letsencrypt::certonly' do
       context 'when specifying additional arguments' do
         let(:title) { 'foo.example.com' }
         let(:params) { { additional_args: ['--foo bar', '--baz quux'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com --foo bar --baz quux' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a standalone -d foo.example.com --foo bar --baz quux' }
       end
 
       describe 'when specifying custom environment variables' do


### PR DESCRIPTION
by default, certbot prints escape sequences. in batch-jobs this breaks
the console / log files.