### PR TITLE
Allow custom config dir; FreeBSD support

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -44,6 +44,7 @@ define letsencrypt::certonly (
   Boolean $suppress_cron_output                             = false,
   $cron_before_command                                      = undef,
   $cron_success_command                                     = undef,
+  Stdlib::Unixpath $config_dir                              = $letsencrypt::config_dir,
 ) {
 
   if $plugin == 'webroot' {
@@ -64,7 +65,7 @@ define letsencrypt::certonly (
   }
   $command_end = inline_template('<% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')
   $command = "${command_start}${command_domains}${command_end}"
-  $live_path = inline_template('/etc/letsencrypt/live/<%= @domains.first %>/cert.pem')
+  $live_path = inline_template("${config_dir}/live/<%= @domains.first %>/cert.pem")
 
   $venv_path_var = "VENV_PATH=${letsencrypt::venv_path}"
   exec { "letsencrypt certonly ${title}":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@
 #   This class configures the Let's Encrypt client. This is a private class.
 #
 class letsencrypt::config (
+  $config_dir          = $letsencrypt::config_dir,
   $config_file         = $letsencrypt::config_file,
   $config              = $letsencrypt::config,
   $email               = $letsencrypt::email,
@@ -16,7 +17,7 @@ class letsencrypt::config (
     fail("You must agree to the Let's Encrypt Terms of Service! See: https://letsencrypt.org/repository for more information." )
   }
 
-  file { '/etc/letsencrypt': ensure => directory }
+  file { $config_dir: ensure => directory }
 
   file { $letsencrypt::cron_scripts_path:
     ensure => directory,
@@ -38,7 +39,7 @@ class letsencrypt::config (
         section => '',
         setting => 'register-unsafely-without-email',
         value   => true,
-        require => File['/etc/letsencrypt'],
+        require => File[$config_dir],
       }
     } else {
       fail("Please specify an email address to register with Let's Encrypt using the \$email parameter on the letsencrypt class")

--- a/manifests/config/ini.pp
+++ b/manifests/config/ini.pp
@@ -10,6 +10,7 @@ define letsencrypt::config::ini () {
   $setting = $name_split[0]
   $value = $name_split[1]
   $config_file = $::letsencrypt::config::config_file
+  $config_dir = $::letsencrypt::config::config_dir
 
   ini_setting { "${config_file} ${setting} ${value}":
     ensure  => present,
@@ -17,7 +18,7 @@ define letsencrypt::config::ini () {
     section => '',
     setting => $setting,
     value   => $value,
-    require => File['/etc/letsencrypt'],
+    require => File[$config_dir],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,8 @@
 # [*package_command*]
 #   Path or name for letsencrypt executable when installing the client with
 #   the `package` method.
+# [*config_dir*]
+#   The path to the configuration directory.
 # [*config_file*]
 #   The path to the configuration file for the letsencrypt cli.
 # [*config*]
@@ -69,6 +71,7 @@ class letsencrypt (
   Enum['package', 'vcs'] $install_method = $letsencrypt::params::install_method,
   Boolean $agree_tos                     = $letsencrypt::params::agree_tos,
   Boolean $unsafe_registration           = $letsencrypt::params::unsafe_registration,
+  Stdlib::Unixpath $config_dir           = $letsencrypt::params::config_dir,
 ) inherits letsencrypt::params {
 
   if $manage_install {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,6 @@ class letsencrypt::params {
   $manage_install      = true
   $manage_dependencies = true
   $package_ensure      = 'installed'
-  $config_file         = '/etc/letsencrypt/cli.ini'
   $path                = '/opt/letsencrypt'
   $venv_path           = '/opt/letsencrypt/.venv' # virtualenv path for vcs-installed letsencrypt
   $repo                = 'https://github.com/letsencrypt/letsencrypt.git'
@@ -19,23 +18,35 @@ class letsencrypt::params {
     $install_method = 'package'
     $package_name = 'certbot'
     $package_command = 'certbot'
+    $config_dir = '/etc/letsencrypt'
   } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $install_method = 'package'
     $package_name = 'letsencrypt'
     $package_command = 'letsencrypt'
+    $config_dir = '/etc/letsencrypt'
   } elsif $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >= 0 {
     $install_method = 'package'
     $package_name = 'certbot'
     $package_command = 'certbot'
+    $config_dir = '/etc/letsencrypt'
   } elsif $::osfamily == 'Gentoo' {
     $install_method = 'package'
     $package_name = 'app-crypt/certbot'
     $package_command = 'certbot'
+    $config_dir = '/etc/letsencrypt'
+  } elsif $::osfamily == 'FreeBSD' {
+    $install_method = 'package'
+    $package_name = 'py27-certbot'
+    $package_command = 'certbot'
+    $config_dir = '/usr/local/etc/letsencrypt'
   } else {
     $install_method = 'vcs'
     $package_name = 'letsencrypt'
     $package_command = 'letsencrypt'
+    $config_dir = '/etc/letsencrypt'
   }
+
+  $config_file = "${config_dir}/cli.ini"
 
   if $::osfamily == 'RedHat' {
     $configure_epel = true

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,13 @@
         "7",
         "8"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -102,6 +102,11 @@ describe 'letsencrypt' do
           it { is_expected.to contain_exec('initialize letsencrypt').with_command('/opt/letsencrypt/letsencrypt-auto -h') }
         end
 
+        describe 'with custom config directory' do
+          let(:additional_params) { { config_dir: '/foo/bar/baz' } }
+          it { is_expected.to contain_file('/foo/bar/baz').with(ensure: 'directory') }
+        end
+
         context 'when not agreeing to the TOS' do
           let(:params) { { agree_tos: false } }
 
@@ -238,6 +243,22 @@ describe 'letsencrypt' do
         is_expected.to contain_class('letsencrypt::install').with(install_method: 'package').with(package_name: 'app-crypt/certbot')
         is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
         is_expected.to contain_package('letsencrypt').with(name: 'app-crypt/certbot')
+      end
+    end
+  end
+
+  context 'on FreeBSD operating system' do
+    let(:facts) { { osfamily: 'FreeBSD', operatingsystem: 'FreeBSD', operatingsystemrelease: '10.3-RELEASE-p7', operatingsystemmajrelease: '10', path: '/usr/bin' } }
+    let(:params) { { email: 'foo@example.com' } }
+
+    describe 'with defaults' do
+      it { is_expected.to compile }
+
+      it 'contains the correct resources' do
+        is_expected.to contain_class('letsencrypt::install').with(install_method: 'package').with(package_name: 'py27-certbot')
+        is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
+        is_expected.to contain_package('letsencrypt').with(name: 'py27-certbot')
+        is_expected.to contain_file('/usr/local/etc/letsencrypt').with(ensure: 'directory')
       end
     end
   end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -159,6 +159,19 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1" }
       end
+
+      context 'with custom config_dir' do
+        let(:title) { 'foo.example.com' }
+        let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com', config_dir => '/foo/bar/baz'}" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(creates: '/foo/bar/baz/live/foo.example.com/cert.pem') }
+      end
     end
+  end
+
+  context 'on FreeBSD' do
+    let(:title) { 'foo.example.com' }
+    let(:facts) { { osfamily: 'FreeBSD', operatingsystem: 'FreeBSD', operatingsystemrelease: '10.3-RELEASE-p7', operatingsystemmajrelease: '10', path: '/usr/bin' } }
+    let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com'}" }
+    it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(creates: '/usr/local/etc/letsencrypt/live/foo.example.com/cert.pem', command: %r{^certbot}) }
   end
 end


### PR DESCRIPTION
* Adds a parameter `config_dir` to provide an absolute path to the
configuration directory.
  * Defaults to '/etc/letsencrypt' except on FreeBSD, where it defaults to
'/usr/local/etc/letsencrypt', as FreeBSD standard and expected by
`py27-certbot`.