### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module installs the Let's Encrypt client from source and allows you to requ
 
 ## Support
 
-This module requires Puppet >= 3.4. and is currently only written to work on
+This module requires Puppet >= 3.8.7. and is currently only written to work on
 Debian and RedHat based operating systems, although it may work on others.
 
 ## Dependencies

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0"
+      "version_requirement": ">= 3.8.7 <5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions