### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,11 +53,11 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">=1.4.0 <2.0.0"
+      "version_requirement": ">=1.4.1 <2.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">=1.3.0 <2.0.0"
+      "version_requirement": ">=1.3.1 <2.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
Bump dependencies to the minimum version that should work
under Puppet 4, based on the metadata