### PR TITLE
Removing --quiet from certonly cron

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -71,7 +71,7 @@ define letsencrypt::certonly (
   }
 
   if $manage_cron {
-    $renewcommand = "${command_start}--keep-until-expiring --quiet ${command_domains}${command_end}"
+    $renewcommand = "${command_start}--keep-until-expiring ${command_domains}${command_end}"
     if $cron_success_command {
       $cron_cmd = "${renewcommand} && (${cron_success_command})"
     } else {

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -70,7 +70,7 @@ describe 'letsencrypt::certonly' do
           { plugin: 'apache',
             manage_cron: true }
         end
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring --quiet -d foo.example.com' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -80,7 +80,7 @@ describe 'letsencrypt::certonly' do
             manage_cron: true,
             cron_success_command: 'echo success' }
         end
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring --quiet -d foo.example.com && (echo success)' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)' }
       end
 
       context 'with invalid plugin' do


### PR DESCRIPTION
Newer version of LetsEncrypt do not use the `--quiet` parameter:

```letsencrypt: error: unrecognized arguments: --quiet```