### PR TITLE
Stdlib validate_legacy

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,7 @@ fixtures:
       ref: '1.4.2'
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.9.0'
+      ref: '4.14.0'
     vcsrepo:
       repo: 'https://github.com/puppetlabs/puppetlabs-vcsrepo.git'
       ref: '1.3.1'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@
 #   `package` method.
 # [*package_command*]
 #   Path or name for letsencrypt executable when installing the client with
-#   the `package` method. 
+#   the `package` method.
 # [*config_file*]
 #   The path to the configuration file for the letsencrypt cli.
 # [*config*]
@@ -67,14 +67,15 @@ class letsencrypt (
   $agree_tos           = $letsencrypt::params::agree_tos,
   $unsafe_registration = $letsencrypt::params::unsafe_registration,
 ) inherits letsencrypt::params {
-  validate_string($path, $repo, $version, $config_file, $package_name, $package_command)
+
+  validate_legacy('Stdlib::Compat::String','validate_string', $path, $repo, $version, $config_file, $package_name, $package_command)
   if $email {
-    validate_string($email)
+    validate_legacy('Stdlib::Compat::String','validate_string', $email)
   }
-  validate_array($environment)
-  validate_bool($manage_config, $manage_install, $manage_dependencies, $configure_epel, $agree_tos, $unsafe_registration)
-  validate_hash($config)
-  validate_re($install_method, ['^package$', '^vcs$'])
+  validate_legacy('Stdlib::Compat::Array', 'validate_array', $environment)
+  validate_legacy('Stdlib::Compat::Bool', 'validate_bool', $manage_config, $manage_install, $manage_dependencies, $configure_epel, $agree_tos, $unsafe_registration)
+  validate_legacy('Stdlib::Compat::Hash', 'validate_hash', $config)
+  validate_legacy('Optional[String]', 'validate_re', $install_method, ['^package$', '^vcs$'])
 
   if $manage_install {
     contain letsencrypt::install # lint:ignore:relative_classname_inclusion

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0 <5.0.0"
+      "version_requirement": ">=4.13.0 <5.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
Replacing `validate_*` function calls with `validate_legacy`, and bumping fixture and dependency versions.