### PR TITLE
Added custom_plugin param in certonly to disable use of '-a' flag.

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -33,17 +33,17 @@
 #   succeeds.
 #
 define letsencrypt::certonly (
-  Array $domains                                   = [$title],
-  $custom_plugin        = false,
-  Enum['apache', 'standalone', 'webroot'] $plugin  = 'standalone',
-  Optional[Array] $webroot_paths                   = undef,
-  String $letsencrypt_command                      = $letsencrypt::command,
-  Optional[Array] $additional_args                 = undef,
-  Array $environment                               = [],
-  Boolean $manage_cron                             = false,
-  Boolean $suppress_cron_output                    = false,
-  $cron_before_command                             = undef,
-  $cron_success_command                            = undef,
+  Array $domains                                            = [$title],
+  Boolean $custom_plugin                                    = false,
+  Enum['apache', 'standalone', 'webroot', 'nginx'] $plugin  = 'standalone',
+  Optional[Array] $webroot_paths                            = undef,
+  String $letsencrypt_command                               = $letsencrypt::command,
+  Optional[Array] $additional_args                          = undef,
+  Array $environment                                        = [],
+  Boolean $manage_cron                                      = false,
+  Boolean $suppress_cron_output                             = false,
+  $cron_before_command                                      = undef,
+  $cron_success_command                                     = undef,
 ) {
 
   if $plugin == 'webroot' {
@@ -51,7 +51,6 @@ define letsencrypt::certonly (
       fail("The 'webroot_paths' parameter must be specified when using the 'webroot' plugin")
     }
   }
-  validate_bool($custom_plugin)
 
   if ($custom_plugin) {
     $command_start = "${letsencrypt_command} --text --agree-tos certonly "

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -117,6 +117,7 @@ describe 'letsencrypt::certonly' do
       context 'without plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { custom_plugin: true } }
+
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -d foo.example.com' }
       end
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -114,6 +114,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
       end
 
+      context 'without plugin' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { custom_plugin: true } }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -d foo.example.com' }
+      end
+
       context 'with invalid plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'bad' } }


### PR DESCRIPTION
I need to validate my domain using DNS, which I found is possible with external_auth plugin. 
Using this plugin with certbot however requires '-a <plugin>' flag to be removed from the certbot command.

This fix introduces a new parameter and does not break any existing code. As an extra, I allowed nginx as plugin, which is also supported now in certbot.