### PR TITLE
fix "-":12: command too long. errors in crontab file, can't install.

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -94,8 +94,15 @@ define letsencrypt::certonly (
     }
     $cron_hour = fqdn_rand(24, $title) # 0 - 23, seed is title plus fqdn
     $cron_minute = fqdn_rand(60, $title ) # 0 - 59, seed is title plus fqdn
+    file { "/usr/local/sbin/letsencrypt-renew-cron-${title}":
+      ensure  => 'file',
+      mode    => '0755',
+      owner   => 'root',
+      group   => 'root',
+      content => "#!/bin/sh\n${cron_cmd}",
+    }
     cron { "letsencrypt renew cron ${title}":
-      command     => $cron_cmd,
+      command     => "/usr/local/sbin/letsencrypt-renew-cron-${title}",
       environment => concat([ $venv_path_var ], $environment),
       user        => root,
       hour        => $cron_hour,

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -94,7 +94,7 @@ define letsencrypt::certonly (
     }
     $cron_hour = fqdn_rand(24, $title) # 0 - 23, seed is title plus fqdn
     $cron_minute = fqdn_rand(60, $title ) # 0 - 59, seed is title plus fqdn
-    file { "/usr/local/sbin/letsencrypt-renew-cron-${title}":
+    file { "${::letsencrypt::cron_scripts_path}/renew-${title}.sh":
       ensure  => 'file',
       mode    => '0755',
       owner   => 'root',
@@ -102,7 +102,7 @@ define letsencrypt::certonly (
       content => "#!/bin/sh\n${cron_cmd}",
     }
     cron { "letsencrypt renew cron ${title}":
-      command     => "/usr/local/sbin/letsencrypt-renew-cron-${title}",
+      command     => "${::letsencrypt::cron_scripts_path}/renew-${title}.sh",
       environment => concat([ $venv_path_var ], $environment),
       user        => root,
       hour        => $cron_hour,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,11 @@ class letsencrypt::config (
 
   file { '/etc/letsencrypt': ensure => directory }
 
+  file { $letsencrypt::cron_scripts_path:
+    ensure => directory,
+    purge  => true,
+  }
+
   if $email {
     $_config = merge($config, {'email' => $email})
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,8 @@
 #   A flag to agree to the Let's Encrypt Terms of Service.
 # [*unsafe_registration*]
 #   A flag to allow using the 'register-unsafely-without-email' flag.
+# [*cron_scripts_path*]
+#   The path to put the script we'll call with cron. Defaults to $puppet_vardir/letsencrypt.
 #
 class letsencrypt (
   $email               = undef,
@@ -59,6 +61,7 @@ class letsencrypt (
   $package_command     = $letsencrypt::params::package_command,
   $config_file         = $letsencrypt::params::config_file,
   $config              = $letsencrypt::params::config,
+  $cron_scripts_path   = $letsencrypt::params::cron_scripts_path,
   $manage_config       = $letsencrypt::params::manage_config,
   $manage_install      = $letsencrypt::params::manage_install,
   $manage_dependencies = $letsencrypt::params::manage_dependencies,
@@ -67,7 +70,7 @@ class letsencrypt (
   $agree_tos           = $letsencrypt::params::agree_tos,
   $unsafe_registration = $letsencrypt::params::unsafe_registration,
 ) inherits letsencrypt::params {
-  validate_string($path, $repo, $version, $config_file, $package_name, $package_command)
+  validate_string($path, $repo, $version, $config_file, $package_name, $package_command, $cron_scripts_path)
   if $email {
     validate_string($email)
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class letsencrypt::params {
   $path                = '/opt/letsencrypt'
   $venv_path           = '/opt/letsencrypt/.venv' # virtualenv path for vcs-installed letsencrypt
   $repo                = 'https://github.com/letsencrypt/letsencrypt.git'
+  $cron_scripts_path   = "${::puppet_vardir}/letsencrypt" # path for renewal scripts called by cron
   $version             = 'v0.9.3'
   $config              = {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -12,3 +12,4 @@ concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+puppet_vardir: "/tmp/LE_puppet_vardir"

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -81,7 +81,8 @@ describe 'letsencrypt::certonly' do
             manage_cron: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
+        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com" }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -93,7 +94,8 @@ describe 'letsencrypt::certonly' do
             cron_success_command: 'echo success' }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
+        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
       end
 
       context 'with invalid plugin' do
@@ -131,7 +133,8 @@ describe 'letsencrypt::certonly' do
             suppress_cron_output: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --text --agree-tos certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
+        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1" }
       end
     end
   end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -81,8 +81,20 @@ describe 'letsencrypt::certonly' do
             manage_cron: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
-        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com" }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_file('/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com" }
+      end
+
+      context 'with custom puppet_vardir path and manage_cron' do
+        let(:facts) { { osfamily: osfamily, operatingsystem: osfamily, operatingsystemrelease: osversion, operatingsystemmajrelease: osversion.split('.').first, path: '/usr/bin', puppet_vardir: '/tmp/custom_vardir' } }
+        let(:title) { 'foo.example.com' }
+        let(:params) do
+          { plugin: 'apache',
+            manage_cron: true }
+        end
+
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com" }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -94,8 +106,8 @@ describe 'letsencrypt::certonly' do
             cron_success_command: 'echo success' }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
-        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_file('/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
       end
 
       context 'with invalid plugin' do
@@ -133,8 +145,8 @@ describe 'letsencrypt::certonly' do
             suppress_cron_output: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/usr/local/sbin/letsencrypt-renew-cron-foo.example.com' }
-        it { is_expected.to contain_file('/usr/local/sbin/letsencrypt-renew-cron-foo.example.com').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1" }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_file('/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1" }
       end
     end
   end


### PR DESCRIPTION
When handling a certificate with >50 altnames with `$manage_cron = true`, the cron command generated was too long to be installed by puppet:
```
Notice: /Stage[main]/Profiles[...]/Letsencrypt::Certonly[default]/Cron[letsencrypt renew cron default]/ensure: created
"-":12: command too long
errors in crontab file, can't install.
Notice: Applied catalog in 28.44 seconds
```

This PR proposes to move the renew command in a script, and call this script with the cron daemon.

NB:  puppet run didn't fail on this crontab error, but this is another problem.