### PR TITLE
Use the correct package names on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ The module can integrate with [stahnma/epel](https://forge.puppetlabs.com/stahnm
 to set up the repo by setting the `configure_epel` parameter to `true` (the default for RedHat) and
 installing the module.
 
+On Debian Jessie the module assumes the package certbot is available. This
+package can be found in jessie-backports. When using
+[puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) the following code
+can be used:
+
+```puppet
+include ::apt
+include ::apt::backports
+apt::pin { 'jessie-backports-letsencrypt':
+  release  => 'jessie-backports',
+  packages => prefix(['acme', 'cryptography', 'openssl', 'psutil', 'setuptools', 'pyasn1', 'pkg-resources'], 'python-'),
+  priority => 700,
+}
+```
+
 ## Usage
 
 To install the Let's Encrypt client with the default configuration settings you

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,10 +14,10 @@ class letsencrypt::params {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',
   }
 
-  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0 {
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0 {
     $install_method = 'package'
-    $package_name = 'letsencrypt'
-    $package_command = 'letsencrypt'
+    $package_name = 'certbot'
+    $package_command = 'certbot'
   } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $install_method = 'package'
     $package_name = 'letsencrypt'

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -183,7 +183,7 @@ describe 'letsencrypt' do
       it { is_expected.to compile }
 
       it 'contains the correct resources' do
-        is_expected.to contain_class('letsencrypt::install').with(install_method: 'vcs')
+        is_expected.to contain_class('letsencrypt::install').with(install_method: 'package')
       end
     end
   end


### PR DESCRIPTION
This also allows using jessie-backports. Replaces https://github.com/voxpupuli/puppet-letsencrypt/pull/76.