### PR TITLE
add manual plugin option

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -43,7 +43,7 @@ define letsencrypt::certonly (
   $cron_success_command = undef,
 ) {
   validate_array($domains)
-  validate_re($plugin, ['^apache$', '^standalone$', '^webroot$'])
+  validate_re($plugin, ['^apache$', '^standalone$', '^webroot$', '^manual$'])
   if $webroot_paths {
     validate_array($webroot_paths)
   } elsif $plugin == 'webroot' {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This plugin is needed to enable DNS authentication.
With this small change this snippet works:
```
  letsencrypt::certonly { $certname:
    domains         => $domains,
    plugin          => 'manual',
    additional_args => [
      '--preferred-challenges dns',
      '--non-interactive',
      '--manual-public-ip-logging-ok',
      '--manual-auth-hook /usr/local/bin/updatechallenge.sh',
      '--expand',
    ],
 } 
```
