### PR TITLE
Add parameters to customize cron's hour and minute

### DIFF
--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -110,6 +110,41 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/tmp/LE_puppet_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
       end
 
+      context 'with custom hour and minute' do
+        let(:title) { 'foo.example.com' }
+        let(:params) do
+          { manage_cron: true,
+            cron_hour: 23,
+            cron_minute: 59 }
+        end
+        it {
+          is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour '23'
+          is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute '59'
+        }
+      end
+
+      context 'with invalid custom hour' do
+        let(:title) { 'foo.example.com' }
+        let(:params) do
+          { manage_cron: true,
+            cron_hour: 27 }
+        end
+        it {
+          is_expected.to raise_error Puppet::Error
+        }
+      end
+
+      context 'with invalid custom minute' do
+        let(:title) { 'foo.example.com' }
+        let(:params) do
+          { manage_cron: true,
+            cron_minute: 60 }
+        end
+        it {
+          is_expected.to raise_error Puppet::Error
+        }
+      end
+
       context 'with invalid plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'bad' } }


### PR DESCRIPTION
When having many certificates managed by LE on the same host, the random function to set minutes and hours does not work that well. As a consequence, errors are raised when some "race condition" happens (in log file rotation for ex).

Also, one may want to restrict the time where cron can be run (only during night for ex).

This PR add 2 parameters to specifically set cron's hour and minute. Having them enables easy customization of every cron run time, without having to fully disable the manage_cron stuff and manage everything (command line etc ...) yourself.