### PR TITLE
fixed randomness if the domain is almost same

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -85,7 +85,7 @@ define letsencrypt::certonly (
       $cron_cmd = $renewcommand
     }
     $cron_hour = fqdn_rand(24, $title) # 0 - 23, seed is title plus fqdn
-    $cron_minute = fqdn_rand(60, $title ) # 0 - 59, seed is title plus fqdn
+    $cron_minute = fqdn_rand(60, fqdn_rand_string(10,$title)) # 0 - 59, seed is title plus fqdn
     file { "${::letsencrypt::cron_scripts_path}/renew-${title}.sh":
       ensure  => 'file',
       mode    => '0755',


### PR DESCRIPTION
like example.com and www.example.com, having same cron timing which was getting failed, because certbot can't have two instance at the same time

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
