### PR TITLE
#91: Cron should also run with space in certonly title

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -125,7 +125,7 @@ define letsencrypt::certonly (
       content => template('letsencrypt/renew-script.sh.erb'),
     }
     cron { "letsencrypt renew cron ${title}":
-      command  => "${::letsencrypt::cron_scripts_path}/renew-${title}.sh",
+      command  => "\"${::letsencrypt::cron_scripts_path}/renew-${title}.sh\"",
       user     => root,
       hour     => $cron_hour,
       minute   => $cron_minute,

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -83,7 +83,7 @@ describe 'letsencrypt::certonly' do
           }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -197,7 +197,7 @@ describe 'letsencrypt::certonly' do
             manage_cron: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh"' }
         it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -212,7 +212,7 @@ describe 'letsencrypt::certonly' do
           }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com && (echo success)\n" }
       end
 
@@ -258,7 +258,7 @@ describe 'letsencrypt::certonly' do
             suppress_cron_output: true }
         end
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n" }
       end
 


### PR DESCRIPTION
Issue #91 reports that creating a letsencrypt::certonly resource with a
title containing a space will create a cron entry that will never run.
That's because it will create a cron entry like this:

    10 22 * * * /cron_scripts_path/renew-title with space.sh

That executes ```/cron_scripts_path/renew-title``` that obviously does not
exist. When the full cron command is put in quotes, it will run as
expected.