### PR TITLE
Add OpenBSD support

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -98,7 +98,7 @@ define letsencrypt::certonly (
       ensure  => 'file',
       mode    => '0755',
       owner   => 'root',
-      group   => "${::letsencrypt::cron_owner_group}",
+      group   => $::letsencrypt::cron_owner_group,
       content => "#!/bin/sh\n${cron_cmd}",
     }
     cron { "letsencrypt renew cron ${title}":

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -98,7 +98,7 @@ define letsencrypt::certonly (
       ensure  => 'file',
       mode    => '0755',
       owner   => 'root',
-      group   => 'root',
+      group   => "${::letsencrypt::cron_owner_group}",
       content => "#!/bin/sh\n${cron_cmd}",
     }
     cron { "letsencrypt renew cron ${title}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,9 +47,8 @@ class letsencrypt::params {
     $configure_epel = false
   }
 
-  if $::osfamily == 'OpenBSD' {
-    $cron_owner_group = 'wheel'
-  } else {
-    $cron_owner_group = 'root'
+  $cron_owner_group = $::osfamily ? {
+    'OpenBSD' =>  'wheel',
+    default   =>  'root',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,10 @@ class letsencrypt::params {
     $install_method = 'package'
     $package_name = 'app-crypt/certbot'
     $package_command = 'certbot'
+  } elsif $::osfamily == 'OpenBSD' {
+    $install_method = 'package'
+    $package_name = 'certbot'
+    $package_command = 'certbot'
   } else {
     $install_method = 'vcs'
     $package_name = 'letsencrypt'
@@ -41,5 +45,11 @@ class letsencrypt::params {
     $configure_epel = true
   } else {
     $configure_epel = false
+  }
+
+  if $::osfamily == 'OpenBSD' {
+    $cron_owner_group = 'wheel'
+  } else {
+    $cron_owner_group = 'root'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-letsencrypt",
-  "version": "2.2.1-rc0",
+  "version": "2.2.1-rc1",
   "author": "Vox Pupuli",
   "summary": "Manages lets-encrypt and certbot + related certs",
   "license": "Apache-2.0",
@@ -36,6 +36,12 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8"
+      ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "6.2"
       ]
     }
   ],

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -241,4 +241,18 @@ describe 'letsencrypt' do
       end
     end
   end
+  context 'on OpenBSD operating system' do
+    let(:facts) { { osfamily: 'OpenBSD', operatingsystem: 'OpenBSD', operatingsystemrelease: '6.2', operatingsystemmajrelease: '6', path: '/usr/bin' } }
+    let(:params) { { email: 'foo@example.com' } }
+
+    describe 'with defaults' do
+      it { is_expected.to compile }
+
+      it 'contains the correct resources' do
+        is_expected.to contain_class('letsencrypt::install').with(install_method: 'package').with(package_name: 'certbot')
+        is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
+        is_expected.to contain_package('letsencrypt').with(name: 'certbot')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Low touch OpenBSD support.

Required adding a new parameter for the file group for cronjob management.

There is a failing test, but it fails against current master also.