### PR TITLE
Support dns-route53 plugin

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -35,7 +35,7 @@
 define letsencrypt::certonly (
   Array $domains                                            = [$title],
   Boolean $custom_plugin                                    = false,
-  Enum['apache', 'standalone', 'webroot', 'nginx'] $plugin  = 'standalone',
+  Enum['apache', 'standalone', 'webroot', 'nginx', 'dns-route53'] $plugin  = 'standalone',
   Optional[Array] $webroot_paths                            = undef,
   String $letsencrypt_command                               = $letsencrypt::command,
   Optional[Array] $additional_args                          = undef,


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for the `dns-route53` plugin, so certificate requests can be authenticated via AWS Route 53 DNS records.

#### This Pull Request (PR) fixes the following issues
Fixes #118
