### PR TITLE
Fix cron environment leaking

### DIFF
--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -84,7 +84,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com\n" }
       end
 
       context 'with custom puppet_vardir path and manage_cron' do
@@ -96,7 +96,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com" }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com\n" }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -111,7 +111,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\n(echo before) && letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)\n" }
       end
 
       context 'without plugin' do
@@ -146,7 +146,7 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
 
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring -d foo.example.com\n" }
       end
 
       context 'with manage cron and suppress_cron_output' do
@@ -157,7 +157,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1\n" }
       end
 
       context 'with custom config_dir' do

--- a/templates/renew-script.sh.erb
+++ b/templates/renew-script.sh.erb
@@ -1,0 +1,5 @@
+#!/bin/sh
+<%- @execution_environment.each do |environment| -%>
+export <%= environment %>
+<%- end -%>
+<%= @cron_cmd %>


### PR DESCRIPTION
This commit moves the environment variable definition from the cron
resource environment parameter to the renewal script. This ensure that
environment variables aren't conflicting with other cronjobs.

Fixes GH-125.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
