### PR TITLE
Fix live directory for wildcard certificates

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -65,7 +65,7 @@ define letsencrypt::certonly (
   }
   $command_end = inline_template('<% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')
   $command = "${command_start}${command_domains}${command_end}"
-  $live_path = inline_template("${config_dir}/live/<%= @domains.first %>/cert.pem")
+  $live_path = inline_template("${config_dir}/live/<%= @domains.first.gsub('*.','') %>/cert.pem")
 
   $venv_path_var = "VENV_PATH=${letsencrypt::venv_path}"
   exec { "letsencrypt certonly ${title}":

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -21,6 +21,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone -d foo.example.com -d bar.example.com' }
       end
 
+      context 'with wildcard domain' do
+        let(:title) { 'foo' }
+        let(:params) { { domains: [ '*.example.com'] } }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_creates '/etc/letsencrypt/live/example.com/cert.pem'}
+      end
+
       context 'with custom command' do
         let(:title) { 'foo.example.com' }
         let(:params) { { letsencrypt_command: '/usr/lib/letsencrypt/letsencrypt-auto' } }

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -23,8 +23,9 @@ describe 'letsencrypt::certonly' do
 
       context 'with wildcard domain' do
         let(:title) { 'foo' }
-        let(:params) { { domains: [ '*.example.com'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_creates '/etc/letsencrypt/live/example.com/cert.pem'}
+        let(:params) { { domains: ['*.example.com'] } }
+
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_creates '/etc/letsencrypt/live/example.com/cert.pem' }
       end
 
       context 'with custom command' do


### PR DESCRIPTION

#### Pull Request (PR) description

When issuing wildcard certificates, the created 'live' directory omits the wildcard character : 
`*.example.com` certificate files are located in `/etc/letsencrypt/live/example.com/` directory. 
The exec relies on the correct path for `creates`, in order not to run every time.
This PR removes the `*.` in the domain name when present.

