### PR TITLE
Remove using package for 16.04, as it installs package 0.4.1-1 instea…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,11 +19,6 @@ class letsencrypt::params {
     $package_name = 'certbot'
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
-  } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
-    $install_method = 'package'
-    $package_name = 'letsencrypt'
-    $package_command = 'letsencrypt'
-    $config_dir = '/etc/letsencrypt'
   } elsif $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >= 0 {
     $install_method = 'package'
     $package_name = 'certbot'


### PR DESCRIPTION
#### Pull Request (PR) description
Removes Ubuntu 16.04 exception (which causes it to use the default of $install_method = 'vcs')

#### This Pull Request (PR) fixes the following issues
Fixes #131 