### PR TITLE
Bug/proper domain validation

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -65,10 +65,10 @@ define letsencrypt::certonly (
         "-d ${domain[0]}"
       }
     }
-    $command_domains = join($_command_domains, ' ')
+    $command_domains = join([ "--cert-name ${title}", ] + $_command_domains, ' ')
   } else {
     $_command_domains = join($domains, ' -d ')
-    $command_domains  = "-d ${_command_domains}"
+    $command_domains  = "--cert-name ${title} -d ${_command_domains}"
   }
 
   if empty($additional_args) {
@@ -82,11 +82,12 @@ define letsencrypt::certonly (
   $live_path = "${config_dir}/live/${domains[0]}/cert.pem"
 
   $execution_environment = [ "VENV_PATH=${letsencrypt::venv_path}", ] + $environment
+  $verify_domains = join($domains, ' -d ')
   exec { "letsencrypt certonly ${title}":
     command     => $command,
     path        => $::path,
     environment => $execution_environment,
-    creates     => $live_path,
+    unless      => "test -f ${live_path} && ${letsencrypt_command} certificates --cert-name ${title} -d ${verify_domains} | grep -q 'Certificate Path'",
     require     => Class['letsencrypt'],
   }
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -10,22 +10,22 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
 
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_creates '/etc/letsencrypt/live/foo.example.com/cert.pem' }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "test -f /etc/letsencrypt/live/foo.example.com/cert.pem && letsencrypt certificates --cert-name foo.example.com -d foo.example.com | grep -q 'Certificate Path'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone --cert-name foo.example.com -d foo.example.com' }
       end
 
       context 'with multiple domains' do
         let(:title) { 'foo' }
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'] } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone --cert-name foo -d foo.example.com -d bar.example.com' }
       end
 
       context 'with custom command' do
         let(:title) { 'foo.example.com' }
         let(:params) { { letsencrypt_command: '/usr/lib/letsencrypt/letsencrypt-auto' } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto --text --agree-tos --non-interactive certonly -a standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto --text --agree-tos --non-interactive certonly -a standalone --cert-name foo.example.com -d foo.example.com' }
       end
 
       context 'with webroot plugin' do
@@ -35,7 +35,7 @@ describe 'letsencrypt::certonly' do
             webroot_paths: ['/var/www/foo'] }
         end
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --webroot-path /var/www/foo -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --cert-name foo.example.com --webroot-path /var/www/foo -d foo.example.com' }
       end
 
       context 'with webroot plugin and multiple domains' do
@@ -46,7 +46,7 @@ describe 'letsencrypt::certonly' do
             webroot_paths: ['/var/www/foo', '/var/www/bar'] }
         end
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --cert-name foo --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
       end
 
       context 'with webroot plugin, one webroot, and multiple domains' do
@@ -57,7 +57,7 @@ describe 'letsencrypt::certonly' do
             webroot_paths: ['/var/www/foo'] }
         end
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --webroot-path /var/www/foo -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a webroot --cert-name foo --webroot-path /var/www/foo -d foo.example.com -d bar.example.com' }
       end
 
       context 'with webroot plugin and no webroot_paths' do
@@ -71,7 +71,7 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a apache -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a apache --cert-name foo.example.com -d foo.example.com' }
       end
 
       context 'with custom plugin and manage cron' do
@@ -84,7 +84,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
       context 'with custom puppet_vardir path and manage_cron' do
@@ -96,7 +96,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com\n" }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -111,14 +111,14 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com && (echo success)\n" }
       end
 
       context 'without plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { custom_plugin: true } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly --cert-name foo.example.com -d foo.example.com' }
       end
 
       context 'with invalid plugin' do
@@ -132,7 +132,7 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         let(:params) { { additional_args: ['--foo bar', '--baz quux'] } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone -d foo.example.com --foo bar --baz quux' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone --cert-name foo.example.com -d foo.example.com --foo bar --baz quux' }
       end
 
       describe 'when specifying custom environment variables' do
@@ -146,7 +146,7 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
 
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
       context 'with manage cron and suppress_cron_output' do
@@ -157,14 +157,14 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/var/lib/puppet/letsencrypt/renew-foo.example.com.sh' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring -d foo.example.com > /dev/null 2>&1\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n" }
       end
 
       context 'with custom config_dir' do
         let(:title) { 'foo.example.com' }
-        let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com', config_dir => '/foo/bar/baz'}" }
+        let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com', config_dir => '/foo/bar/baz', package_command => 'letsencrypt'}" }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(creates: '/foo/bar/baz/live/foo.example.com/cert.pem') }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(unless: "test -f /foo/bar/baz/live/foo.example.com/cert.pem && letsencrypt certificates --cert-name foo.example.com -d foo.example.com | grep -q 'Certificate Path'") }
       end
     end
   end
@@ -174,6 +174,6 @@ describe 'letsencrypt::certonly' do
     let(:facts) { { osfamily: 'FreeBSD', operatingsystem: 'FreeBSD', operatingsystemrelease: '10.3-RELEASE-p7', operatingsystemmajrelease: '10', path: '/usr/bin' } }
     let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com'}" }
 
-    it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(creates: '/usr/local/etc/letsencrypt/live/foo.example.com/cert.pem', command: %r{^certbot}) }
+    it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with(unless: "test -f /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem && certbot certificates --cert-name foo.example.com -d foo.example.com | grep -q 'Certificate Path'", command: %r{^certbot}) }
   end
 end

--- a/spec/type_aliases/plugin_spec.rb
+++ b/spec/type_aliases/plugin_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'Letsencrypt::Plugin' do
+  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google') }
+  it { is_expected.not_to allow_value(nil) }
+  it { is_expected.not_to allow_value('foo') }
+  it { is_expected.not_to allow_value('custom') }
+end

--- a/types/plugin.pp
+++ b/types/plugin.pp
@@ -1,0 +1,1 @@
+type Letsencrypt::Plugin = Enum['apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google']


### PR DESCRIPTION
#### Pull Request (PR) description
This PR contains two commits:

1. Refactoring:
```
Remove inline_template in favour of native Puppet code

* Migrates all inline_template calls to Puppet native code, as this is
recommended best practice
* Changes the default value/data type of webroot_paths and
additional_args to an Array instead of Optional[Array]
* Adds a data type for the certificate plugins for better readability
```

2. Bug fix for expanding a certificate
```
Allow additional domains to be added later

This commit adds support for expansion/shrinking of an already existing
certificate by defining a unique identifier (--cert-name) which maps to
the Puppet resource title. By doing this, we can ensure that always all
requested domains are contained in the certificate.
```

#### This Pull Request (PR) fixes the following issues
Fixes #94
