### PR TITLE
Allow wildcard domains for certonly::domains

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -33,7 +33,7 @@
 #   succeeds.
 #
 define letsencrypt::certonly (
-  Array[Stdlib::Host]     $domains              = [$title],
+  Array[String[1]]        $domains              = [$title],
   Boolean                 $custom_plugin        = false,
   Letsencrypt::Plugin     $plugin               = 'standalone',
   Array[Stdlib::Unixpath] $webroot_paths        = [],

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -16,9 +16,9 @@ describe 'letsencrypt::certonly' do
 
       context 'with multiple domains' do
         let(:title) { 'foo' }
-        let(:params) { { domains: ['foo.example.com', 'bar.example.com'] } }
+        let(:params) { { domains: ['foo.example.com', 'bar.example.com', '*.example.com'] } }
 
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone --cert-name foo -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --text --agree-tos --non-interactive certonly -a standalone --cert-name foo -d foo.example.com -d bar.example.com -d *.example.com' }
       end
 
       context 'with custom command' do


### PR DESCRIPTION
#### Pull Request (PR) description

The current datatype `Array[Stdlib::Host]` for `certonly::domains` is too strict and does not allow for domains containing asterisks to generate wildcard certificates. 

My proposed change would be:
`Array[Stdlib::Host]` -> `Array[String[1]]`

Feel free to implement some other validation pattern in case `Array[String[1]]` is too loose.


Bonus: Added a case of `*.example.com` to spec test (excluding webroot plugin since you need the DNS-01 challenge)