### PR TITLE
make the module compatible with FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,6 +61,7 @@ class letsencrypt::params {
 
   $cron_owner_group = $::osfamily ? {
     'OpenBSD' =>  'wheel',
+    'FreeBSD' =>  'wheel',
     default   =>  'root',
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

As FreeBSD also has no `root` group, the only change I noticed would be necessary to successfully run this module on FreeBSD is the same like for OpenBSD.