### PR TITLE
Fix exec onlyif logic

### DIFF
--- a/files/domain-validation.sh
+++ b/files/domain-validation.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# THIS FILE IS MANAGED BY PUPPET
+
+# First parameter is the certificate path
+# All other parameters are the domain names requested for the certificate
+# Split whitespace into newlines to let it play nicely with sort
+certpath="${1}"
+shift
+domains=$(echo "${@}" | tr ' ' '\n')
+
+# If certpath doesn't exist, run the exec
+if ! test -f ${certpath}; then
+  exit 1
+fi
+
+# Get all subject alternative names from the certificate
+certdomains=$(openssl x509 -in ${certpath} -text -noout | grep -oP 'DNS:[^\s,]*' | sed 's/^DNS://g;')
+
+# Sort and uniq all domains. Drop all Domains which occure twice
+result=$(echo "${certdomains}\n${domains}" | sort | uniq -c | grep -Pcv '^[ \t]*2[ \t]')
+
+# If all requested domains are already in the certificate, the $result will be 0 otherwise > 0
+if [ ${result} -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -97,9 +97,12 @@ define letsencrypt::certonly (
     command     => $command,
     path        => $::path,
     environment => $execution_environment,
-    unless      => "test -f ${live_path} && ! ( openssl x509 -in ${live_path} -text -noout | grep -oE 'DNS:[^\s,]*' | sed 's/^DNS://g;'; echo '${verify_domains}' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'",
+    unless      => "/usr/local/sbin/letsencrypt-domain-validation ${live_path} ${verify_domains}",
     provider    => 'shell',
-    require     => Class['letsencrypt'],
+    require     => [
+      Class['letsencrypt'],
+      File['/usr/local/sbin/letsencrypt-domain-validation'],
+    ],
   }
 
   if $ensure_cron  == 'present' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,4 +101,13 @@ class letsencrypt (
     environment => concat([ "VENV_PATH=${venv_path}" ], $environment),
     refreshonly => true,
   }
+
+  # Used in letsencrypt::certonly Exec["letsencrypt certonly ${title}"]
+  file { '/usr/local/sbin/letsencrypt-domain-validation':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0500',
+    source => "puppet:///modules/${module_name}/domain-validation.sh",
+  }
 }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -17,6 +17,15 @@ describe 'letsencrypt' do
 
           epel = facts[:osfamily] == 'RedHat'
 
+          it 'contains File[/usr/local/sbin/letsencrypt-domain-validation]' do
+            is_expected.to contain_file('/usr/local/sbin/letsencrypt-domain-validation').
+              with_ensure('file').
+              with_owner('root').
+              with_group('root').
+              with_mode('0500').
+              with_source('puppet:///modules/letsencrypt/domain-validation.sh')
+          end
+
           it 'contains the correct resources' do
             is_expected.to contain_class('letsencrypt::install').with(configure_epel: epel,
                                                                       manage_install: true,

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -38,7 +38,7 @@ describe 'letsencrypt::certonly' do
         end
         it { is_expected.to contain_exec('initialize letsencrypt') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "test -f #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem && ! ( openssl x509 -in #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "/usr/local/sbin/letsencrypt-domain-validation #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem foo.example.com" }
       end
 
       context 'with multiple domains' do
@@ -333,7 +333,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/foo/bar/baz').with_ensure('directory') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "test -f /foo/bar/baz/live/foo.example.com/cert.pem && ! ( openssl x509 -in /foo/bar/baz/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless '/usr/local/sbin/letsencrypt-domain-validation /foo/bar/baz/live/foo.example.com/cert.pem foo.example.com' }
       end
 
       context 'on FreeBSD', if: facts[:os]['name'] == 'FreeBSD' do
@@ -345,7 +345,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini email foo@example.com') }
         it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory') }
         it { is_expected.to contain_file('/usr/local/etc/letsencrypt').with_ensure('directory') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "test -f /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem && ! ( openssl x509 -in /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless '/usr/local/sbin/letsencrypt-domain-validation /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem foo.example.com' }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This commit fixes the improved check logic introduces in
460a7b7cd9cca267e5cb35568ccf4cc88faa97f0. It ensure that the exec is
actually triggered if the cert file doesn't exist.

**Current master:**

* Cert doesn't exist:
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted.de/cert.pem
ls: cannot access /etc/letsencrypt/live/www.redacted.de/cert.pem: No such file or directory
root@lb:/# test -f /etc/letsencrypt/live/www.redacted.de/cert.pem && ( openssl x509 -in /etc/letsencrypt/live/www.redacted.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted.de redacted.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
1
```
==> Wouldn't run

* Cert does exists but one domain is missing
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted2.de/cert.pem
lrwxrwxrwx 1 root root 47 Dec 13 12:17 /etc/letsencrypt/live/www.redacted2.de/cert.pem -> ../../archive/www.redacted2.de/cert1.pem
root@lb:/# openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*'
DNS:redacted2.de
DNS:www.redacted2.de
root@lb:/# test -f /etc/letsencrypt/live/www.redacted2.de/cert.pem && ( openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted2.de redacted2.de foo.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
0
```
==> Would run

* Cert does exists and all domains match
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted2.de/cert.pem
lrwxrwxrwx 1 root root 47 Dec 13 12:17 /etc/letsencrypt/live/www.redacted2.de/cert.pem -> ../../archive/www.redacted2.de/cert1.pem
root@lb:/# openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*'
DNS:redacted2.de
DNS:www.redacted2.de
root@lb:/# test -f /etc/letsencrypt/live/www.redacted2.de/cert.pem && ( openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted2.de redacted2.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
1
```
==> Wouldn't run

**This change:**

* Cert doesn't exist:
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted.de/cert.pem
ls: cannot access /etc/letsencrypt/live/www.redacted.de/cert.pem: No such file or directory
root@lb:/# test -f /etc/letsencrypt/live/www.redacted.de/cert.pem && ! ( openssl x509 -in /etc/letsencrypt/live/www.redacted.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted.de redacted.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
1
```
==> Would run

* Cert does exists but one domain is missing
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted2.de/cert.pem
lrwxrwxrwx 1 root root 47 Dec 13 12:17 /etc/letsencrypt/live/www.redacted2.de/cert.pem -> ../../archive/www.redacted2.de/cert1.pem
root@lb:/# openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*'
DNS:redacted2.de
DNS:www.redacted2.de
root@lb:/# test -f /etc/letsencrypt/live/www.redacted2.de/cert.pem && ! ( openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted2.de redacted2.de foo.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
1
```
==> Would run

* Cert does exists and all domains match
```
root@lb:/# ls -la /etc/letsencrypt/live/www.redacted2.de/cert.pem
lrwxrwxrwx 1 root root 47 Dec 13 12:17 /etc/letsencrypt/live/www.redacted2.de/cert.pem -> ../../archive/www.redacted2.de/cert1.pem
root@lb:/# openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*'
DNS:redacted2.de
DNS:www.redacted2.de
root@lb:/# test -f /etc/letsencrypt/live/www.redacted2.de/cert.pem && ! ( openssl x509 -in /etc/letsencrypt/live/www.redacted2.de/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'www.redacted2.de redacted2.de' | tr ' ' '\n') | sort | uniq -c | grep -qv '^[ ]*2[ ]'
root@lb:/# echo $?
0
```
==> Wouldn't run


#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
