### PR TITLE
Certonly: Refactor manage_cron to ensure_cron with appropriate data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ letsencrypt::certonly { 'foo':
 }
 ```
 
-* `manage_cron` can be used to automatically renew the certificate
+* `ensure_cron` can be used to automatically renew the certificate
 * `cron_success_command` can be used to run a shell command on a successful renewal
 * `cron_before_command` can be used to run a shell command before a renewal
 * `cron_monthday` can be used to specify one or multiple days of the month to run the cron job (defaults to every day)
@@ -141,7 +141,7 @@ letsencrypt::certonly { 'foo':
 ```puppet
 letsencrypt::certonly { 'foo':
   domains              => ['foo.example.com', 'bar.example.com'],
-  manage_cron          => true,
+  ensure_cron          => 'present',
   cron_hour            => [0,12],
   cron_minute          => '30',
   cron_before_command  => 'service nginx stop',

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -104,6 +104,8 @@ define letsencrypt::certonly (
   if $manage_cron {
     $maincommand = "${command_start}--keep-until-expiring ${command_domains}${command_end}"
     $cron_ensure = present
+    $cron_script_ensure = 'file'
+
     if $suppress_cron_output {
       $croncommand = "${maincommand} > /dev/null 2>&1"
     } else {
@@ -119,15 +121,17 @@ define letsencrypt::certonly (
     } else {
       $cron_cmd = $renewcommand
     }
-    file { "${::letsencrypt::cron_scripts_path}/renew-${title}.sh":
-      ensure  => 'file',
-      mode    => '0755',
-      owner   => 'root',
-      group   => $::letsencrypt::cron_owner_group,
-      content => template('letsencrypt/renew-script.sh.erb'),
-    }
   } else {
     $cron_ensure = absent
+    $cron_script_ensure = absent
+  }
+
+  file { "${::letsencrypt::cron_scripts_path}/renew-${title}.sh":
+    ensure  => $cron_script_ensure,
+    mode    => '0755',
+    owner   => 'root',
+    group   => $::letsencrypt::cron_owner_group,
+    content => template('letsencrypt/renew-script.sh.erb'),
   }
 
   cron { "letsencrypt renew cron ${title}":

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -103,6 +103,7 @@ define letsencrypt::certonly (
 
   if $manage_cron {
     $maincommand = "${command_start}--keep-until-expiring ${command_domains}${command_end}"
+    $cron_ensure = present
     if $suppress_cron_output {
       $croncommand = "${maincommand} > /dev/null 2>&1"
     } else {
@@ -125,12 +126,17 @@ define letsencrypt::certonly (
       group   => $::letsencrypt::cron_owner_group,
       content => template('letsencrypt/renew-script.sh.erb'),
     }
-    cron { "letsencrypt renew cron ${title}":
-      command  => "\"${::letsencrypt::cron_scripts_path}/renew-${title}.sh\"",
-      user     => root,
-      hour     => $cron_hour,
-      minute   => $cron_minute,
-      monthday => $cron_monthday,
-    }
+  } else {
+    $cron_ensure = absent
   }
+
+  cron { "letsencrypt renew cron ${title}":
+    ensure   => $cron_ensure,
+    command  => "\"${::letsencrypt::cron_scripts_path}/renew-${title}.sh\"",
+    user     => root,
+    hour     => $cron_hour,
+    minute   => $cron_minute,
+    monthday => $cron_monthday,
+  }
+
 }

--- a/spec/acceptance/letsencrypt_certonly_spec.rb
+++ b/spec/acceptance/letsencrypt_certonly_spec.rb
@@ -12,7 +12,7 @@ describe 'letsencrypt::certonly' do
 
       letsencrypt::certonly { 'foo':
         domains              => ['foo.example.com', 'bar.example.com'],
-        manage_cron          => true,
+        ensure_cron          => 'present',
         cron_hour            => [0,12],
         cron_minute          => '30',
         cron_before_command  => 'service apache stop',

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -22,6 +22,8 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_class('Letsencrypt::Install') }
         it { is_expected.to contain_class('Letsencrypt::Config') }
         it { is_expected.to contain_class('Letsencrypt::Params') }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_ensure('absent') }
+
         case facts[:kernel]
         when 'Linux'
           it { is_expected.to contain_file('/etc/letsencrypt') }
@@ -115,7 +117,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -129,7 +131,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour 13 }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour(13).with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -156,7 +158,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour '00' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour('00').with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -170,7 +172,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour [1, 13] }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour([1, 13]).with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -184,7 +186,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute 15 }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute(15).with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -211,7 +213,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute '15' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute('15').with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -225,7 +227,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute [0, 30] }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute([0, 30]).with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
@@ -308,7 +310,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n" }
       end
 
@@ -320,7 +322,7 @@ describe 'letsencrypt::certonly' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with(monthday: [1, 15]) }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with(monthday: [1, 15]).with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -23,6 +23,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_class('Letsencrypt::Config') }
         it { is_expected.to contain_class('Letsencrypt::Params') }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_ensure('absent') }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('absent') }
 
         case facts[:kernel]
         when 'Linux'
@@ -118,7 +119,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and defined cron_hour (integer)' do
@@ -132,7 +133,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour(13).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -159,7 +160,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour('00').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and defined cron_hour (array)' do
@@ -173,7 +174,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour([1, 13]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and defined cron_minute (integer)' do
@@ -187,7 +188,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute(15).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -214,7 +215,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute('15').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with manage_cron and defined cron_minute (array)' do
@@ -228,7 +229,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute([0, 30]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with custom puppet_vardir path and manage_cron' do
@@ -244,7 +245,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt').with_ensure('directory') }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -260,7 +261,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && #{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com && (echo success)\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && #{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com && (echo success)\n") }
       end
 
       context 'without plugin' do
@@ -311,7 +312,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n") }
       end
 
       context 'with manage cron and custom day of month' do
@@ -323,7 +324,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with(monthday: [1, 15]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
       context 'with custom config_dir' do

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -108,12 +108,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --cert-name foo.example.com -d foo.example.com" }
       end
 
-      context 'with custom plugin and manage_cron' do
+      context 'with custom plugin and ensure_cron' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             plugin: 'apache',
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -122,12 +122,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and defined cron_hour (integer)' do
+      context 'with ensure_cron and defined cron_hour (integer)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_hour: 13,
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -136,12 +136,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and out of range defined cron_hour (integer)' do
+      context 'with ensure_cron and out of range defined cron_hour (integer)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_hour: 24,
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -149,12 +149,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to raise_error Puppet::Error }
       end
 
-      context 'with manage_cron and defined cron_hour (string)' do
+      context 'with ensure_cron and defined cron_hour (string)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_hour: '00',
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -163,12 +163,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and defined cron_hour (array)' do
+      context 'with ensure_cron and defined cron_hour (array)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_hour: [1, 13],
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -177,12 +177,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and defined cron_minute (integer)' do
+      context 'with ensure_cron and defined cron_minute (integer)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_minute: 15,
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -191,12 +191,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and out of range defined cron_hour (integer)' do
+      context 'with ensure_cron and out of range defined cron_hour (integer)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_hour: 66,
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -204,12 +204,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to raise_error Puppet::Error }
       end
 
-      context 'with manage_cron and defined cron_minute (string)' do
+      context 'with ensure_cron and defined cron_minute (string)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_minute: '15',
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -218,12 +218,12 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with manage_cron and defined cron_minute (array)' do
+      context 'with ensure_cron and defined cron_minute (array)' do
         let(:title) { 'foo.example.com' }
         let(:params) do
           {
             cron_minute: [0, 30],
-            manage_cron: true
+            ensure_cron: 'present'
           }
         end
 
@@ -232,14 +232,14 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
       end
 
-      context 'with custom puppet_vardir path and manage_cron' do
+      context 'with custom puppet_vardir path and ensure_cron' do
         let :facts do
           super().merge(puppet_vardir: '/tmp/custom_vardir')
         end
         let(:title) { 'foo.example.com' }
         let(:params) do
           { plugin: 'apache',
-            manage_cron: true }
+            ensure_cron: 'present' }
         end
 
         it { is_expected.to compile.with_all_deps }
@@ -253,7 +253,7 @@ describe 'letsencrypt::certonly' do
         let(:params) do
           {
             plugin: 'apache',
-            manage_cron: true,
+            ensure_cron: 'present',
             cron_before_command: 'echo before',
             cron_success_command: 'echo success'
           }
@@ -295,18 +295,18 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
       end
 
-      context 'with custom environment variables and manage_cron' do
+      context 'with custom environment variables and ensure_cron' do
         let(:title) { 'foo.example.com' }
-        let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
+        let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], ensure_cron: 'present' } }
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
       end
 
-      context 'with manage cron and suppress_cron_output' do
+      context 'with manage cron and suppress_cron_output' do\
         let(:title) { 'foo.example.com' }
         let(:params) do
-          { manage_cron: true,
+          { ensure_cron: 'present',
             suppress_cron_output: true }
         end
 
@@ -318,7 +318,7 @@ describe 'letsencrypt::certonly' do
       context 'with manage cron and custom day of month' do
         let(:title) { 'foo.example.com' }
         let(:params) do
-          { manage_cron: true,
+          { ensure_cron: 'present',
             cron_monthday: [1, 15] }
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Ensures cron is removed when `manage_cron` is `false`.

#### This Pull Request (PR) fixes the following issues
Fixes #139 
