### PR TITLE
Certonly: Exec doesn't run if file doesn't exist (regression from 460a7b7c)

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -96,7 +96,7 @@ define letsencrypt::certonly (
     command     => $command,
     path        => $::path,
     environment => $execution_environment,
-    onlyif      => "test -f ${live_path} && ( openssl x509 -in ${live_path} -text -noout | grep -oE 'DNS:[^\s,]*' | sed 's/^DNS://g;'; echo '${verify_domains}' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'",
+    onlyif      => "(openssl x509 -in ${live_path} -text -noout | grep -oE 'DNS:[^\s,]*' | sed 's/^DNS://g;'; echo '${verify_domains}' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'",
     provider    => 'shell',
     require     => Class['letsencrypt'],
   }

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -35,7 +35,7 @@ describe 'letsencrypt::certonly' do
         end
         it { is_expected.to contain_exec('initialize letsencrypt') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "test -f #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem && ( openssl x509 -in #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "(openssl x509 -in #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
       end
 
       context 'with multiple domains' do
@@ -330,7 +330,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/foo/bar/baz').with_ensure('directory') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "test -f /foo/bar/baz/live/foo.example.com/cert.pem && ( openssl x509 -in /foo/bar/baz/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "(openssl x509 -in /foo/bar/baz/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
       end
 
       context 'on FreeBSD', if: facts[:os]['name'] == 'FreeBSD' do
@@ -342,7 +342,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini email foo@example.com') }
         it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory') }
         it { is_expected.to contain_file('/usr/local/etc/letsencrypt').with_ensure('directory') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "test -f /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem && ( openssl x509 -in /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_onlyif "(openssl x509 -in /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem -text -noout | grep -oE 'DNS:[^ ,]*' | sed 's/^DNS://g;'; echo 'foo.example.com' | tr ' ' '\\n') | sort | uniq -c | grep -qv '^[ \t]*2[ \t]'" }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Removes the `test` within the `certonly` define's `exec` resource - the `openssl` command will automatically fail if the file doesn't exist.

#### This Pull Request (PR) fixes the following issues
Fixes a regression where the `exec` command doesn't run if the file doesn't already exist.
