### PR TITLE
Fedora doesn't use EPEL for certbot/letsencrypt.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,7 +59,11 @@ class letsencrypt::params {
   $config_file = "${config_dir}/cli.ini"
 
   if $facts['osfamily'] == 'RedHat' {
-    $configure_epel = true
+    if $facts['lsbdistid'] == 'Fedora' {
+      $configure_epel = false
+   } else {
+      $configure_epel = true
+   }
   } else {
     $configure_epel = false
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,11 +59,7 @@ class letsencrypt::params {
   $config_file = "${config_dir}/cli.ini"
 
   if $facts['osfamily'] == 'RedHat' {
-    if $facts['lsbdistid'] == 'Fedora' {
-      $configure_epel = false
-   } else {
-      $configure_epel = true
-   }
+    $configure_epel = $facts['os']['name'] != 'Fedora'
   } else {
     $configure_epel = false
   }


### PR DESCRIPTION
#### Pull Request (PR) description
Fedora doesn't use EPEL functionality for certbot/letsencrypt

#### This Pull Request (PR) fixes the following issues
No Issue was created.