### PR TITLE
Add support for dns-rfc2136 plugin

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -96,7 +96,7 @@ define letsencrypt::certonly (
   $verify_domains = join(unique($domains), ' ')
   exec { "letsencrypt certonly ${title}":
     command     => $command,
-    path        => $::path,
+    path        => $facts['path'],
     environment => $execution_environment,
     unless      => "/usr/local/sbin/letsencrypt-domain-validation ${live_path} ${verify_domains}",
     provider    => 'shell',
@@ -129,17 +129,17 @@ define letsencrypt::certonly (
     $cron_script_ensure = 'absent'
   }
 
-  file { "${::letsencrypt::cron_scripts_path}/renew-${title}.sh":
+  file { "${letsencrypt::cron_scripts_path}/renew-${title}.sh":
     ensure  => $cron_script_ensure,
     mode    => '0755',
     owner   => 'root',
-    group   => $::letsencrypt::cron_owner_group,
+    group   => $letsencrypt::cron_owner_group,
     content => template('letsencrypt/renew-script.sh.erb'),
   }
 
   cron { "letsencrypt renew cron ${title}":
     ensure   => $ensure_cron,
-    command  => "\"${::letsencrypt::cron_scripts_path}/renew-${title}.sh\"",
+    command  => "\"${letsencrypt::cron_scripts_path}/renew-${title}.sh\"",
     user     => root,
     hour     => $cron_hour,
     minute   => $cron_minute,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class letsencrypt (
   # TODO: do we need this command when installing from package?
   exec { 'initialize letsencrypt':
     command     => "${command_init} -h",
-    path        => $::path,
+    path        => $facts['path'],
     environment => concat([ "VENV_PATH=${venv_path}" ], $environment),
     refreshonly => true,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,4 +69,10 @@ class letsencrypt::params {
     'FreeBSD' =>  'wheel',
     default   =>  'root',
   }
+
+  $dns_rfc2136_manage_package      = true
+  $dns_rfc2136_port                = 53
+  $dns_rfc2136_algorithm           = 'HMAC-SHA512'
+  $dns_rfc2136_propagation_seconds = 10
+
 }

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -1,0 +1,59 @@
+# == Class: letsencrypt::plugin::dns_rfc2136
+#
+#   This class installs and configures the Let's Encrypt dns-rfc2136 plugin.
+#   https://certbot-dns-rfc2136.readthedocs.io
+#
+# === Parameters:
+#
+# [*server*]
+#   Target DNS server.
+# [*key_name*]
+#   TSIG key name.
+# [*key_secret*]
+#   TSIG key secret.
+# [*key_algorithm*]
+#   TSIG key algorithm.
+# [*port*]
+#   Target DNS port.
+# [*manage_package*]
+#   Manage the plugin package.
+# [*config_dir*]
+#   The path to the configuration directory.
+#
+class letsencrypt::plugin::dns_rfc2136 (
+  Stdlib::Host $server,
+  String[1] $key_name,
+  String[1] $key_secret,
+  String[1] $key_algorithm         = $letsencrypt::params::dns_rfc2136_algorithm,
+  Stdlib::Port $port               = $letsencrypt::params::dns_rfc2136_port,
+  Integer $propagation_seconds     = $letsencrypt::params::dns_rfc2136_propagation_seconds,
+  Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
+  Boolean $manage_package          = $letsencrypt::params::dns_rfc2136_manage_package,
+) {
+
+  if ($manage_package) {
+    package { 'python2-certbot-dns-rfc2136':
+      ensure => installed,
+    }
+  }
+
+  $ini_vars = {
+    dns_rfc2136_server    => $server,
+    dns_rfc2136_port      => $port,
+    dns_rfc2136_name      => $key_name,
+    dns_rfc2136_secret    => $key_secret,
+    dns_rfc2136_algorithm => $key_algorithm,
+  }
+
+  file { "${config_dir}/dns-rfc2136.ini":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0400',
+    content => epp('letsencrypt/ini.epp', {
+      vars => { '' => $ini_vars },
+    }),
+    require => Class['letsencrypt'],
+  }
+
+}

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'letsencrypt::plugin::dns_rfc2136' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
+
+    let(:params) { default_params.merge(required_params).merge(additional_params) }
+    let(:default_params) do
+      { key_algorithm: 'HMAC-SHA512',
+        port: 53,
+        manage_package: true,
+        config_dir: '/etc/letsencrypt',
+        propagation_seconds: 10 }
+    end
+    let(:required_params) { {} }
+    let(:additional_params) { {} }
+
+    context 'without required parameters' do
+      it { is_expected.not_to compile }
+    end
+
+    context "on #{os} based operating systems" do
+      let(:required_params) do
+        { server: '1.2.3.4',
+          key_name: 'certbot',
+          key_secret: 'secret' }
+      end
+      let(:pre_condition) do
+        "class { letsencrypt:
+          email           => 'foo@example.com',
+          config_dir      => '/etc/letsencrypt',
+          package_command => 'letsencrypt',
+        }"
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      describe 'with manage_package => true' do
+        let(:additional_params) { { manage_package: true } }
+
+        it { is_expected.to contain_package('python2-certbot-dns-rfc2136').with_ensure('installed') }
+      end
+
+      describe 'with manage_package => false' do
+        let(:additional_params) { { manage_package: false } }
+
+        it { is_expected.not_to contain_package('python2-certbot-dns-rfc2136') }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/letsencrypt/dns-rfc2136.ini').with(
+          ensure: 'file',
+          owner: 'root',
+          group: 'root',
+          mode: '0400'
+        ).with_content(%r{^.*dns_rfc2136_server.*$})
+      end
+    end
+  end
+end

--- a/spec/type_aliases/plugin_spec.rb
+++ b/spec/type_aliases/plugin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Letsencrypt::Plugin' do
-  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare') }
+  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare', 'dns-rfc2136') }
   it { is_expected.not_to allow_value(nil) }
   it { is_expected.not_to allow_value('foo') }
   it { is_expected.not_to allow_value('custom') }

--- a/spec/type_aliases/plugin_spec.rb
+++ b/spec/type_aliases/plugin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Letsencrypt::Plugin' do
-  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google') }
+  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare') }
   it { is_expected.not_to allow_value(nil) }
   it { is_expected.not_to allow_value('foo') }
   it { is_expected.not_to allow_value('custom') }

--- a/templates/ini.epp
+++ b/templates/ini.epp
@@ -1,0 +1,21 @@
+<%- |
+  Hash $vars,
+  String $separator = '=',
+| -%>
+# THIS FILE IS MANAGED BY PUPPET
+
+<% $vars.each | String $section, Hash $section_vars | { -%>
+<%   if (!empty($section)) { -%>
+[<%= $section %>]
+<%   } -%>
+<%   $section_vars.each | String $var, Variant[String, Integer, Array] $vals | { -%>
+<%     if ($vals =~ Array) { -%>
+<%       $vals.each | Variant[String, Integer] $val | { -%>
+<%= $var %><%= $separator %><%= $val %>
+<%       } -%>
+<%     } -%>
+<%     else { -%>
+<%= $var %><%= $separator %><%= $vals %>
+<%     } -%>
+<%   } %>
+<% } -%>

--- a/types/plugin.pp
+++ b/types/plugin.pp
@@ -1,1 +1,1 @@
-type Letsencrypt::Plugin = Enum['apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare']
+type Letsencrypt::Plugin = Enum['apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare', 'dns-rfc2136']


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds support for issuing certificates with the Let's Encrypt dns-rfc2136 plugin. Tested on CentOS7.

Three minor bonuses:
- Fixes a small spec bug where `dns-cloudflare` was not being allowed as a value for the Letsencrypt::Plugin type.
- Cleans up some old Puppet 3 syntax
- README gets a header upgrade for better readability (and so usage of this plugin can be documented sanely)

The module already has a dependency on puppetlabs/inifile, but I've used an ini template for (imo) cleaner code. Something to evaluate as well.

#### This Pull Request (PR) fixes the following issues
n/a
