### PR TITLE
Add support for wildcard certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ class { ::letsencrypt:
 }
 ```
 
+To request a wildcard certificate, you must use the ACME v2 endpoint and use
+a DNS-01 challenge. See
+https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578
+
+```puppet
+class { 'letsencrypt':
+  config => {
+    email  => 'foo@example.com',
+    server => 'https://acme-v02.api.letsencrypt.org/directory',
+  }
+}
+```
+
 ### Issuing certificates
 
 #### Standalone authenticator

--- a/files/domain-validation.sh
+++ b/files/domain-validation.sh
@@ -9,18 +9,18 @@ shift
 domains=$(echo "${@}" | tr ' ' '\n')
 
 # If certpath doesn't exist, run the exec
-if ! test -f ${certpath}; then
+if ! test -f "${certpath}"; then
   exit 1
 fi
 
 # Get all subject alternative names from the certificate
-certdomains=$(openssl x509 -in ${certpath} -text -noout | grep -oP 'DNS:[^\s,]*' | sed 's/^DNS://g;')
+certdomains=$(openssl x509 -in "${certpath}" -text -noout | grep -oP 'DNS:[^\s,]*' | sed 's/^DNS://g;')
 
 # Sort and uniq all domains. Drop all Domains which occure twice
-result=$(echo "${certdomains}\n${domains}" | sort | uniq -c | grep -Pcv '^[ \t]*2[ \t]')
+result=$(printf '%s\n%s' "${certdomains}" "${domains}" | sort | uniq -c | grep -Pcv '^[ \t]*2[ \t]')
 
 # If all requested domains are already in the certificate, the $result will be 0 otherwise > 0
-if [ ${result} -eq 0 ]; then
+if [ "${result}" -eq 0 ]; then
   exit 0
 else
   exit 1

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -107,7 +107,8 @@ define letsencrypt::certonly (
   }
 
   $command = "${command_start}${command_domains}${command_end}"
-  $live_path = "${config_dir}/live/${domains[0]}/cert.pem"
+  $live_path_domain = regsubst($domains[0], '^\*\.', '')
+  $live_path = "${config_dir}/live/${live_path_domain}/cert.pem"
 
   $execution_environment = [ "VENV_PATH=${letsencrypt::venv_path}", ] + $environment
   $verify_domains = join(unique($domains), ' ')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds support for issuing wildcard certificates. If the first domain starts with an asterisk, certbot strips it and the first dot from the actual file path.

I don't think there is anything useful that can be added to spec tests for this. Please correct me if I'm wrong.

There is a stale pull request open for the same thing: https://github.com/voxpupuli/puppet-letsencrypt/pull/128

Also fixes a couple things in `files/domain_validation.sh` (I forgot to put these in a separate commit - let me know if you want them separate):

- It attempts to echo a newline with `echo "${certdomains}\n${domains}"`, but this does not work as expected on Red Hat-based distros (and probably others) as you need the (non-POSIX) switch `-e`. I've replaced this with a printf instead, with future support for a wider range of OSes in mind.
- Fixes unquoted variable warnings detected by shellcheck.

#### This Pull Request (PR) fixes the following issues
n/a
