### PR TITLE
Add support for certbot renew and hooks

### DIFF
--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -1,0 +1,40 @@
+# == Defined Type: letsencrypt::hook
+#
+#   This type is used by letsencrypt::renew and letsencrypt::certonly to create
+#   hook scripts.
+#
+# === Parameters:
+#
+# [*type*]
+#   Hook type. Can be pre, post or deploy.
+# [*hook_file*]
+#   Path to deploy hook script.
+# [*commands*]
+#   String or array of bash commands to execute when the hook is run by certbot.
+#
+define letsencrypt::hook (
+  Enum['pre', 'post', 'deploy'] $type,
+  String[1]                     $hook_file,
+  # hook.sh.epp will validate this
+  $commands,
+) {
+
+  $validate_env = $type ? {
+    'deploy' => true,
+    default  => false,
+  }
+
+  file { $hook_file:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => epp('letsencrypt/hook.sh.epp', {
+      commands     => $commands,
+      validate_env => $validate_env,
+    }),
+    # Defined in letsencrypt::config
+    require => File['letsencrypt-renewal-hooks-puppet'],
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,11 +73,21 @@ class letsencrypt (
   Boolean $unsafe_registration           = $letsencrypt::params::unsafe_registration,
   Stdlib::Unixpath $config_dir           = $letsencrypt::params::config_dir,
   Integer[2048] $key_size                = 4096,
+  # $renew_* should only be used in letsencrypt::renew (blame rspec)
+  $renew_pre_hook_commands               = $letsencrypt::params::renew_pre_hook_commands,
+  $renew_post_hook_commands              = $letsencrypt::params::renew_post_hook_commands,
+  $renew_deploy_hook_commands            = $letsencrypt::params::renew_deploy_hook_commands,
+  $renew_additional_args                 = $letsencrypt::params::renew_additional_args,
+  $renew_cron_ensure                     = $letsencrypt::params::renew_cron_ensure,
+  $renew_cron_hour                       = $letsencrypt::params::renew_cron_hour,
+  $renew_cron_minute                     = $letsencrypt::params::renew_cron_minute,
+  $renew_cron_monthday                   = $letsencrypt::params::renew_cron_monthday,
 ) inherits letsencrypt::params {
 
   if $manage_install {
     contain letsencrypt::install # lint:ignore:relative_classname_inclusion
     Class['letsencrypt::install'] ~> Exec['initialize letsencrypt']
+    Class['letsencrypt::install'] -> Class['letsencrypt::renew']
   }
 
   $command = $install_method ? {
@@ -94,6 +104,8 @@ class letsencrypt (
     contain letsencrypt::config # lint:ignore:relative_classname_inclusion
     Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
   }
+
+  contain letsencrypt::renew
 
   # TODO: do we need this command when installing from package?
   exec { 'initialize letsencrypt':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class letsencrypt::params {
     $package_name = 'app-crypt/certbot'
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
-} elsif $facts['osfamily'] == 'OpenBSD' {
+  } elsif $facts['osfamily'] == 'OpenBSD' {
     $install_method = 'package'
     $package_name = 'certbot'
     $package_command = 'certbot'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,6 +70,15 @@ class letsencrypt::params {
     default   =>  'root',
   }
 
+  $renew_pre_hook_commands    = []
+  $renew_post_hook_commands   = []
+  $renew_deploy_hook_commands = []
+  $renew_additional_args      = []
+  $renew_cron_ensure          = 'absent'
+  $renew_cron_hour            = fqdn_rand(24)
+  $renew_cron_minute          = fqdn_rand(60, fqdn_rand_string(10))
+  $renew_cron_monthday        = '*'
+
   $dns_rfc2136_manage_package      = true
   $dns_rfc2136_port                = 53
   $dns_rfc2136_algorithm           = 'HMAC-SHA512'

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -15,6 +15,8 @@
 #   TSIG key algorithm.
 # [*port*]
 #   Target DNS port.
+# [*propagation_seconds*]
+#   Number of seconds to wait for the DNS server to propagate the DNS-01 challenge.
 # [*manage_package*]
 #   Manage the plugin package.
 # [*config_dir*]

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -1,0 +1,98 @@
+# == Class: letsencrypt::renew
+#
+#   This class configures renewal of Let's Encrypt certificates using the
+#   certbot renew command.
+#
+#   Note: Hooks set here will run before/after/for ALL certificates, including
+#   any not managed by Puppet. If you want to create hooks for specific
+#   certificates only, create them using letsencrypt::certonly.
+#
+# === Parameters:
+#
+# [*pre_hook_commands*]
+#   Array of commands to run in a shell before obtaining/renewing any certificates.
+# [*post_hook_commands*]
+#   Array of commands to run in a shell after attempting to obtain/renew certificates.
+# [*deploy_hook_commands*]
+#   Array of commands to run in a shell once for each successfully issued/renewed
+#   certificate. Two environmental variables are supplied by certbot:
+#   - $RENEWED_LINEAGE: Points to the live directory with the cert files and key.
+#                       Example: /etc/letsencrypt/live/example.com
+#   - $RENEWED_DOMAINS: A space-delimited list of renewed certificate domains.
+#                       Example: "example.com www.example.com"
+# [*additional_args*]
+#   Array of additional command line arguments to pass to 'certbot renew'.
+# [*cron_ensure*]
+#   Intended state of the cron resource running certbot renew. Accepts 'present'
+#   or 'absent'. Default: 'absent'
+# [*cron_hour*]
+#   Optional string, integer or array of hour(s) the renewal command should run.
+#   E.g. '[0,12]' to execute at midnight and midday. Default: fqdn-seeded random
+#   hour.
+# [*cron_minute*]
+#   Optional string, integer or array of minute(s) the renewal command should
+#   run. E.g. 0 or '00' or [0,30]. Default: fqdn-seeded random minute.
+# [*cron_monthday*]
+#   Optional string, integer or array of monthday(s) the renewal command should
+#   run. E.g. '2-30/2' to run on even days. Default: Every day.
+#
+class letsencrypt::renew (
+  Variant[String[1], Array[String[1]]] $pre_hook_commands    = $letsencrypt::renew_pre_hook_commands,
+  Variant[String[1], Array[String[1]]] $post_hook_commands   = $letsencrypt::renew_post_hook_commands,
+  Variant[String[1], Array[String[1]]] $deploy_hook_commands = $letsencrypt::renew_deploy_hook_commands,
+  Array[String[1]]                     $additional_args      = $letsencrypt::renew_additional_args,
+  Enum['present', 'absent']            $cron_ensure          = $letsencrypt::renew_cron_ensure,
+  Letsencrypt::Cron::Hour              $cron_hour            = $letsencrypt::renew_cron_hour,
+  Letsencrypt::Cron::Minute            $cron_minute          = $letsencrypt::renew_cron_minute,
+  Letsencrypt::Cron::Monthday          $cron_monthday        = $letsencrypt::renew_cron_monthday,
+) {
+
+  # Directory used for Puppet-managed renewal hooks. Make sure old unmanaged
+  # hooks in this directory are purged. Leave custom hooks in the default
+  # renewal-hooks directory alone.
+  file { 'letsencrypt-renewal-hooks-puppet':
+    ensure  => directory,
+    path    => "${letsencrypt::config_dir}/renewal-hooks-puppet",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    recurse => true,
+    purge   => true,
+  }
+
+  $default_args = 'renew -q'
+
+  $hook_args = ['pre', 'post', 'deploy'].map | String $type | {
+    $commands = getvar("${type}_hook_commands")
+    if (!empty($commands)) {
+      $hook_file = "${letsencrypt::config_dir}/renewal-hooks-puppet/renew-${type}.sh"
+      letsencrypt::hook { "renew-${type}":
+        type      => $type,
+        hook_file => $hook_file,
+        commands  => $commands,
+      }
+      "--${type}-hook \"${hook_file}\""
+    }
+    else {
+      undef
+    }
+  }
+
+  $_command = flatten([
+    $letsencrypt::command,
+    $default_args,
+    $hook_args,
+    $additional_args,
+  ]).filter | $arg | { $arg =~ NotUndef and $arg != [] }
+  $command = join($_command, ' ')
+
+  cron { 'letsencrypt-renew':
+    ensure   => $cron_ensure,
+    command  => $command,
+    user     => 'root',
+    hour     => $cron_hour,
+    minute   => $cron_minute,
+    monthday => $cron_monthday,
+  }
+
+}

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -152,8 +152,50 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
+
+      context 'with hook' do
+        context 'pre' do
+          let(:title) { 'foo.example.com' }
+          let(:params) { { config_dir: '/etc/letsencrypt', pre_hook_commands: ['FooBar'] } }
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_letsencrypt__hook('foo.example.com-pre').with_hook_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-pre.sh')
+          end
+        end
+
+        context 'pre with wildcard domain' do
+          let(:title) { '*.example.com' }
+          let(:params) { { config_dir: '/etc/letsencrypt', pre_hook_commands: ['FooBar'] } }
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_letsencrypt__hook('*.example.com-pre').with_hook_file('/etc/letsencrypt/renewal-hooks-puppet/example.com-pre.sh')
+          end
+        end
+
+        context 'post' do
+          let(:title) { 'foo.example.com' }
+          let(:params) { { config_dir: '/etc/letsencrypt', post_hook_commands: ['FooBar'] } }
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_letsencrypt__hook('foo.example.com-post').with_hook_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-post.sh')
+          end
+        end
+
+        context 'deploy' do
+          let(:title) { 'foo.example.com' }
+          let(:params) { { config_dir: '/etc/letsencrypt', deploy_hook_commands: ['FooBar'] } }
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_letsencrypt__hook('foo.example.com-deploy').with_hook_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-deploy.sh')
+          end
+        end
+      end # context 'with hook'
 
       context 'with manage_cron and defined cron_hour (integer)' do
         let(:title) { 'foo.example.com' }
@@ -166,7 +208,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour(13).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -193,7 +235,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour('00').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and defined cron_hour (array)' do
@@ -207,7 +249,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour([1, 13]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and defined cron_minute (integer)' do
@@ -221,7 +263,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute(15).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -248,7 +290,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute('15').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and defined cron_minute (array)' do
@@ -262,7 +304,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute([0, 30]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with manage_cron and ensure absent' do
@@ -292,7 +334,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt').with_ensure('directory') }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -308,7 +350,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && #{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --keep-until-expiring --cert-name foo.example.com -d foo.example.com && (echo success)\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && #{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name foo.example.com -d foo.example.com --keep-until-expiring && (echo success)\n") }
       end
 
       context 'without plugin' do
@@ -347,7 +389,7 @@ describe 'letsencrypt::certonly' do
         let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n" }
       end
 
       context 'with manage cron and suppress_cron_output' do\
@@ -359,7 +401,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com > /dev/null 2>&1\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring > /dev/null 2>&1\n") }
       end
 
       context 'with manage cron and custom day of month' do
@@ -371,7 +413,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with(monthday: [1, 15]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --keep-until-expiring --cert-name foo.example.com -d foo.example.com\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n#{binaryprefix}letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name foo.example.com -d foo.example.com --keep-until-expiring\n") }
       end
 
       context 'with custom config_dir' do

--- a/spec/defines/letsencrypt_hook_spec.rb
+++ b/spec/defines/letsencrypt_hook_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'letsencrypt::hook' do
+  on_supported_os.each do |os, _facts|
+    let(:title) { 'foo.example.com' }
+
+    let(:pre_condition) { ["class { letsencrypt: email => 'foo@example.com', package_command => 'letsencrypt' }"] }
+    let(:params) { default_params.merge(required_params).merge(additional_params) }
+    let(:default_params) { {} }
+    let(:required_params) { {} }
+    let(:additional_params) { {} }
+
+    context 'without required parameters' do
+      it { is_expected.not_to compile }
+    end
+
+    context "on #{os} based operating systems" do
+      context 'with pre hook' do
+        let(:required_params) do
+          { type: 'pre',
+            hook_file: '/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-pre.sh',
+            commands: ['FooBar'] }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-pre.sh').
+            with(ensure: 'file',
+                 owner: 'root',
+                 group: 'root',
+                 mode: '0755',
+                 content: %r{^.*validate_env=0.*FooBar.*$}m).
+            that_requires('File[letsencrypt-renewal-hooks-puppet]')
+        end
+      end
+
+      context 'with post hook' do
+        let(:required_params) do
+          { type: 'post',
+            hook_file: '/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-post.sh',
+            commands: ['FooBar'] }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-post.sh').
+            with_content(%r{^.*validate_env=0.*FooBar.*$}m)
+        end
+      end
+
+      describe 'with deploy hook' do
+        let(:required_params) do
+          { type: 'deploy',
+            hook_file: '/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-deploy.sh',
+            commands: ['FooBar'] }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-deploy.sh').
+            with_content(%r{^.*validate_env=1.*FooBar.*$}m)
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/cron_hour_spec.rb
+++ b/spec/type_aliases/cron_hour_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Letsencrypt::Cron::Hour' do
+  describe 'valid handling' do
+    it { is_expected.to allow_values(0, 23, '0', '23', [], [0, '23']) }
+  end
+
+  describe 'invalid handling' do
+    it { is_expected.not_to allow_values(-1, 24, '', '-1', '24', [''], [-1, '24']) }
+  end
+end

--- a/spec/type_aliases/cron_minute_spec.rb
+++ b/spec/type_aliases/cron_minute_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Letsencrypt::Cron::Minute' do
+  describe 'valid handling' do
+    it { is_expected.to allow_values(0, 59, '0', '59', [], [0, '59']) }
+  end
+
+  describe 'invalid handling' do
+    it { is_expected.not_to allow_values(-1, 60, '', '-1', '60', [''], [-1, '60']) }
+  end
+end

--- a/spec/type_aliases/cron_monthday_spec.rb
+++ b/spec/type_aliases/cron_monthday_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Letsencrypt::Cron::Monthday' do
+  describe 'valid handling' do
+    it { is_expected.to allow_values(1, 31, '1', '31', [], [1, '31']) }
+  end
+
+  describe 'invalid handling' do
+    it { is_expected.not_to allow_values(0, 32, '', '0', '32', [''], [0, '32']) }
+  end
+end

--- a/templates/hook.sh.epp
+++ b/templates/hook.sh.epp
@@ -1,0 +1,50 @@
+<%- |
+  Variant[String[1], Array[String[1], 1]] $commands,
+  Boolean $validate_env = false,
+| -%>
+#!/bin/bash
+# THIS FILE IS MANAGED BY PUPPET
+#
+# This script is intended to be used by certbot's hooks. The same simple Puppet
+# template is used for all three hook types (pre, post, deploy).
+#
+# When used as a deploy hook, two environmental variables are supplied by
+# certbot:
+#
+# $RENEWED_LINEAGE : Points to the live directory of the certificate. Eg.
+#                  : /etc/letsencrypt/live/example.com
+# $RENEWED_DOMAINS : Contains a space-delimited list of the certificate's
+#                  : domains. Eg. "example.com www.example.com"
+#
+
+### Configuration
+
+# Puppet sets this to 1 when the template is used for deploy hooks
+validate_env=<%= bool2str($validate_env, '1', '0') %>
+
+### Functions
+
+echo_err() {
+  echo "ERROR: $*" >&2
+}
+
+### Begin script
+
+if [[ "$validate_env" -gt 0 ]]; then
+  bork=0
+  if [[ -z "$RENEWED_DOMAINS" ]]; then
+    bork=1
+    echo_err "Environment variable RENEWED_DOMAINS is empty"
+  fi
+  if [[ -z "$RENEWED_LINEAGE" ]]; then
+    bork=1
+    echo_err "Environment variable RENEWED_LINEAGE is empty"
+  fi
+  [[ "$bork" -gt 0 ]] && exit 1
+fi
+
+<% flatten([$commands]).each | $command | { -%>
+<%= $command %>
+<% } -%>
+
+exit 0

--- a/types/cron/hour.pp
+++ b/types/cron/hour.pp
@@ -1,0 +1,1 @@
+type Letsencrypt::Cron::Hour = Variant[Integer[0,23], String[1], Array[Variant[Integer[0,23], String[1]]]]

--- a/types/cron/minute.pp
+++ b/types/cron/minute.pp
@@ -1,0 +1,1 @@
+type Letsencrypt::Cron::Minute = Variant[Integer[0,59], String[1], Array[Variant[Integer[0,59], String[1]]]]

--- a/types/cron/monthday.pp
+++ b/types/cron/monthday.pp
@@ -1,0 +1,1 @@
+type Letsencrypt::Cron::Monthday = Variant[Integer[0,31], String[1], Array[Variant[Integer[0,31], String[1]]]]


### PR DESCRIPTION
#### Pull Request (PR) description
- Adds support for running `certbot renew` with hooks in cron
- Adds support for hooks in `certbot::certonly` (these are saved in the renew configs by certbot and will also be run by certbot when running `certbot renew`)
- Cleans up argument variables a bit in `certbot::certonly`, as it seemed overdue. Names and variable handling was getting confusing.
- Adds three new types: `Letsencrypt::Cron::Hour` `Letsencrypt::Cron::Minute` `Letsencrypt::Cron::Monthday`

#### This Pull Request (PR) fixes the following issues
Fixes #56 
