### PR TITLE
Fix for $live_path variable

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -107,8 +107,10 @@ define letsencrypt::certonly (
   }
 
   $command = "${command_start}${command_domains}${command_end}"
-  $live_path_domain = regsubst($domains[0], '^\*\.', '')
-  $live_path = "${config_dir}/live/${live_path_domain}/cert.pem"
+
+  # certbot uses --cert-name to generate the file path
+  $live_path_certname = regsubst($title, '^\*\.', '')
+  $live_path = "${config_dir}/live/${live_path_certname}/cert.pem"
 
   $execution_environment = [ "VENV_PATH=${letsencrypt::venv_path}", ] + $environment
   $verify_domains = join(unique($domains), ' ')


### PR DESCRIPTION
Certbot uses the "--cert-name" parameter as part of the path, not the
first domain. This means the computed $live_path would be wrong if
$domain[0] differs from $title.