### PR TITLE
surfacing package_ensure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ class { ::letsencrypt:
 }
 ```
 
+If using Ubuntu16.04 with `install_method` to default `package`, you can enforce upgrade of package from 0.4 to 0.7 with :
+
+```puppet
+class { ::letsencrypt:
+  email          => 'foo@example.com',
+  package_ensure => 'latest',
+}
+```
+
 If using EL7 without EPEL-preconfigured, add `configure_epel`:
 
 ```puppet


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The default install method is to use package from distribution.

Let's Encrypt, as released in Xenial, stopped to work since 13 March 2019 when TLS-SNI-01 validation is turned off by the primary Let's Encrypt CA. This makes the package effectively useless for just about all users.

Ubuntu 16.04 maintainers upgraded the package from 0.4 to 0.7, and so it is necessary to upgrade the package to the new version. The default `ensure => installed` attribute for `package` resource does nothing.

So it looks interesting to explain how to upgrade the package with the puppet module.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
