### PR TITLE
Fix type in readme: deploy_hooks_commands -> deploy_hook_commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ letsencrypt::certonly { 'foo':
   domains               => ['foo.example.com', 'bar.example.com'],
   pre_hook_commands     => ['...'],
   post_hook_commands    => ['...'],
-  deploy_hook_commands => ['...'],
+  deploy_hook_commands  => ['...'],
 }
 ```
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fix type in readme: deploy_hooks_commands -> deploy_hook_commands

#### This Pull Request (PR) fixes the following issues
Typo in README.md