### PR TITLE
Added support for cron environment in renew class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,7 @@ class letsencrypt (
   $renew_cron_hour                       = $letsencrypt::params::renew_cron_hour,
   $renew_cron_minute                     = $letsencrypt::params::renew_cron_minute,
   $renew_cron_monthday                   = $letsencrypt::params::renew_cron_monthday,
+  $renew_cron_environment                = $letsencrypt::params::renew_cron_environment,
 ) inherits letsencrypt::params {
 
   if $manage_install {

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -35,6 +35,9 @@
 # [*cron_monthday*]
 #   Optional string, integer or array of monthday(s) the renewal command should
 #   run. E.g. '2-30/2' to run on even days. Default: Every day.
+# [*cron_environment*]
+#   Optional string, array of environment settings that need to associated with this cron job monthday(s) the renewal command should
+#   run. E.g. MAILTO=info@example.com.
 #
 class letsencrypt::renew (
   Variant[String[1], Array[String[1]]] $pre_hook_commands    = $letsencrypt::renew_pre_hook_commands,
@@ -45,6 +48,7 @@ class letsencrypt::renew (
   Letsencrypt::Cron::Hour              $cron_hour            = $letsencrypt::renew_cron_hour,
   Letsencrypt::Cron::Minute            $cron_minute          = $letsencrypt::renew_cron_minute,
   Letsencrypt::Cron::Monthday          $cron_monthday        = $letsencrypt::renew_cron_monthday,
+  Variant[String[1], Array[String[1]]] $cron_environment     = $letsencrypt::renew_cron_environment,
 ) {
 
   # Directory used for Puppet-managed renewal hooks. Make sure old unmanaged
@@ -86,13 +90,25 @@ class letsencrypt::renew (
   ]).filter | $arg | { $arg =~ NotUndef and $arg != [] }
   $command = join($_command, ' ')
 
-  cron { 'letsencrypt-renew':
-    ensure   => $cron_ensure,
-    command  => $command,
-    user     => 'root',
-    hour     => $cron_hour,
-    minute   => $cron_minute,
-    monthday => $cron_monthday,
+  if (!empty($cron_environment)) {
+    cron { 'letsencrypt-renew':
+      ensure      => $cron_ensure,
+      command     => $command,
+      user        => 'root',
+      hour        => $cron_hour,
+      minute      => $cron_minute,
+      monthday    => $cron_monthday,
+      environment => $cron_environment,
+    }
   }
-
+  else {
+    cron { 'letsencrypt-renew':
+      ensure   => $cron_ensure,
+      command  => $command,
+      user     => 'root',
+      hour     => $cron_hour,
+      minute   => $cron_minute,
+      monthday => $cron_monthday,
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I added support to configure environments for the letsencrypt renew cron job. This way it possible to add for example an email address to send the output from the cronjob.
