### PR TITLE
Add Nginx authenticator plugin to Letsencrypt Puppet module

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ letsencrypt::certonly { 'foo':
 }
 ```
 
+#### Nginx authenticator
+
+To request a certificate for $::fqdn with the `certonly` installer and the `nginx` authenticator, temporarily opening firewall for HTTP, with an already running Nginx, and reloading Nginx afterwards:
+
+```puppet
+letsencrypt::certonly { $::fqdn:
+  domains => [$::fqdn],
+  plugin  => 'nginx',
+  pre_hook_commands     => ['iptables -A INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT -m comment --comment TEMPORARY_LETSENCRYPT'],
+  post_hook_commands    => ['iptables -D INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT -m comment --comment TEMPORARY_LETSENCRYPT', 'systemctl reload nginx'],
+}
+```
+
 #### Webroot plugin
 
 To request a certificate using the `webroot` plugin, the paths to the webroots

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -66,6 +66,7 @@ define letsencrypt::certonly (
   Array[String[1]]                          $environment          = [],
   Boolean                                   $manage_cron          = false,
   Boolean                                   $suppress_cron_output = false,
+  Optional[String]                          $cron_output_mailto   = undef,
   Optional[String[1]]                       $cron_before_command  = undef,
   Optional[String[1]]                       $cron_success_command = undef,
   Array[Variant[Integer[0, 59], String[1]]] $cron_monthday        = ['*'],
@@ -201,6 +202,8 @@ define letsencrypt::certonly (
 
     if $suppress_cron_output {
       $croncommand = "${maincommand} > /dev/null 2>&1"
+    } elsif $cron_output_mailto {
+      $croncommand = "${maincommand} 2>&1 |mail -s 'Letsencrypt cron job' '${cron_output_mailto}'"
     } else {
       $croncommand = $maincommand
     }

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -94,6 +94,18 @@ define letsencrypt::certonly (
     $default_args = '--text --agree-tos --non-interactive delete'
   }
 
+  # Plugin requirements
+  case $plugin {
+
+    'dns-rfc2136': {
+      require letsencrypt::plugin::dns_rfc2136
+    }
+
+    'nginx': {
+      require letsencrypt::plugin::nginx
+    }
+  }
+
   case $plugin {
 
     'webroot': {
@@ -108,7 +120,6 @@ define letsencrypt::certonly (
     }
 
     'dns-rfc2136': {
-      require letsencrypt::plugin::dns_rfc2136
       $_domains = join($domains, '\' -d \'')
       $plugin_args = [
         "--cert-name '${title}' -d",
@@ -118,7 +129,7 @@ define letsencrypt::certonly (
       ]
     }
 
-    default: {
+    'nginx', default: {
       if $ensure == 'present' {
         $_domains = join($domains, '\' -d \'')
         $plugin_args  = "--cert-name '${title}' -d '${_domains}'"

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -104,6 +104,9 @@ define letsencrypt::certonly (
     'nginx': {
       require letsencrypt::plugin::nginx
     }
+
+    default: {
+      # nothing to do, but needed to pass tests
   }
 
   case $plugin {

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -107,6 +107,7 @@ define letsencrypt::certonly (
 
     default: {
       # nothing to do, but needed to pass tests
+    }
   }
 
   case $plugin {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class letsencrypt (
   String $package_name                   = $letsencrypt::params::package_name,
   $package_ensure                        = $letsencrypt::params::package_ensure,
   String $package_command                = $letsencrypt::params::package_command,
+  Boolean $nginx_manage_package          = $letsencrypt::params::nginx_manage_package,
   String $config_file                    = $letsencrypt::params::config_file,
   Hash $config                           = $letsencrypt::params::config,
   String $cron_scripts_path              = $letsencrypt::params::cron_scripts_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class letsencrypt::params {
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = 'python3-certbot-dns-rfc2136'
-    $nginx_package_name = undef
+    $nginx_package_name = 'python3-certbot-nginx'
   } elsif $facts['osfamily'] == 'RedHat' {
     $install_method = 'package'
     $package_name = 'certbot'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class letsencrypt::params {
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = 'python3-certbot-dns-rfc2136'
+    $nginx_package_name = 'python3-certbot-nginx'
   } elsif $facts['osfamily'] == 'RedHat' {
     $install_method = 'package'
     $package_name = 'certbot'
@@ -29,8 +30,10 @@ class letsencrypt::params {
     $config_dir = '/etc/letsencrypt'
     if $facts['operatingsystemmajrelease'] == '7' {
       $dns_rfc2136_package_name = 'python2-certbot-dns-rfc2136'
+      $nginx_package_name = 'python2-certbot-nginx'
     } else {
       $dns_rfc2136_package_name = 'python3-certbot-dns-rfc2136'
+      $nginx_package_name = 'python3-certbot-nginx'
     }
   } elsif $facts['osfamily'] == 'Gentoo' {
     $install_method = 'package'
@@ -38,24 +41,28 @@ class letsencrypt::params {
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = undef
+    $nginx_package_name = undef
   } elsif $facts['osfamily'] == 'OpenBSD' {
     $install_method = 'package'
     $package_name = 'certbot'
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = undef
+    $nginx_package_name = undef
   } elsif $facts['osfamily'] == 'FreeBSD' {
     $install_method = 'package'
     $package_name = 'py27-certbot'
     $package_command = 'certbot'
     $config_dir = '/usr/local/etc/letsencrypt'
     $dns_rfc2136_package_name = undef
+    $nginx_package_name = undef
   } else {
     $install_method = 'vcs'
     $package_name = 'letsencrypt'
     $package_command = 'letsencrypt'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = undef
+    $nginx_package_name = undef
   }
 
   $config_file = "${config_dir}/cli.ini"
@@ -82,4 +89,5 @@ class letsencrypt::params {
   $dns_rfc2136_algorithm           = 'HMAC-SHA512'
   $dns_rfc2136_propagation_seconds = 10
 
+  $nginx_manage_package       = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class letsencrypt::params {
     $package_command = 'certbot'
     $config_dir = '/etc/letsencrypt'
     $dns_rfc2136_package_name = 'python3-certbot-dns-rfc2136'
-    $nginx_package_name = 'python3-certbot-nginx'
+    $nginx_package_name = undef
   } elsif $facts['osfamily'] == 'RedHat' {
     $install_method = 'package'
     $package_name = 'certbot'

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -39,6 +39,10 @@ class letsencrypt::plugin::dns_rfc2136 (
   if $manage_package {
     package { $package_name:
       ensure => installed,
+      install_options => $operatingsystemmajrelease ? {
+        '8'     => '--enablerepo=PowerTools',
+        default => undef,
+      },
     }
   }
 

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -40,7 +40,7 @@ class letsencrypt::plugin::dns_rfc2136 (
     package { $package_name:
       ensure => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=PowerTools',
+        '8'     => '--enablerepo=powertools',
         default => undef,
       },
     }

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -40,7 +40,7 @@ class letsencrypt::plugin::dns_rfc2136 (
     package { $package_name:
       ensure => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=powertools',
+        '8'     => '--enablerepo=PowerTools',
         default => undef,
       },
     }

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -38,9 +38,9 @@ class letsencrypt::plugin::dns_rfc2136 (
 
   if $manage_package {
     package { $package_name:
-      ensure => installed,
+      ensure          => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=PowerTools',
+        '8'     => '--enablerepo=powertools',
         default => undef,
       },
     }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -1,0 +1,23 @@
+# == Class: letsencrypt::plugin::nginx
+#
+#   This class installs and configures the Let's Encrypt nginx plugin.
+#
+# === Parameters:
+#
+# [*manage_package*]
+#   Manage the plugin package.
+# [*package_name*]
+#   The name of the package to install when $manage_package is true.
+#
+class letsencrypt::plugin::nginx (
+  Boolean $manage_package          = $letsencrypt::nginx_manage_package,
+  String $package_name             = $letsencrypt::nginx_package_name,
+) {
+
+  if $manage_package {
+    package { $package_name:
+      ensure => installed,
+    }
+  }
+
+}

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -18,7 +18,7 @@ class letsencrypt::plugin::nginx (
     package { $package_name:
       ensure => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=PowerTools',
+        '8'     => '--enablerepo=powertools',
         default => undef,
       },
     }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -25,7 +25,10 @@ class letsencrypt::plugin::nginx (
 
     file { '/etc/letsencrypt/options-ssl-nginx.conf':
       ensure  => link,
-      target  => '/usr/lib/python3.6/site-packages/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf',
+      target  => $::osfamily ? {
+        'Redhat' => '/usr/lib/python3.6/site-packages/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf',
+        'Debian' => '/usr/lib/python3/dist-packages/certbot_nginx/options-ssl-nginx.conf',
+      },
       require => Package[$package_name],
     }
   }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -16,9 +16,9 @@ class letsencrypt::plugin::nginx (
 
   if $manage_package {
     package { $package_name:
-      ensure => installed,
+      ensure          => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=PowerTools',
+        '8'     => '--enablerepo=powertools',
         default => undef,
       },
     }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -17,6 +17,10 @@ class letsencrypt::plugin::nginx (
   if $manage_package {
     package { $package_name:
       ensure => installed,
+      install_options => $operatingsystemmajrelease ? {
+        '8'     => '--enablerepo=PowerTools',
+        default => undef,
+      },
     }
   }
 

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -18,7 +18,7 @@ class letsencrypt::plugin::nginx (
     package { $package_name:
       ensure => installed,
       install_options => $operatingsystemmajrelease ? {
-        '8'     => '--enablerepo=powertools',
+        '8'     => '--enablerepo=PowerTools',
         default => undef,
       },
     }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -22,6 +22,12 @@ class letsencrypt::plugin::nginx (
         default => undef,
       },
     }
+
+    file { '/etc/letsencrypt/options-ssl-nginx.conf':
+      ensure  => link,
+      target  => '/usr/lib/python3.6/site-packages/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf',
+      require => Package[$package_name],
+    }
   }
 
 }

--- a/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+
+describe 'letsencrypt::plugin::nginx' do
+  supported = case fact('os.family')
+              when 'Debian'
+                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
+                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
+              when 'RedHat'
+                true
+              else
+                false
+              end
+
+  context 'with defaults values' do
+    pp = <<-PUPPET
+      class { 'letsencrypt' :
+        email  => 'letsregister@example.com',
+        config => {
+          'server' => 'https://acme-staging.api.letsencrypt.org/directory',
+        },
+      }
+      class { 'letsencrypt::plugin::nginx':
+      }
+    PUPPET
+
+    if supported
+      it 'installs letsencrypt and nginx plugin without error' do
+        apply_manifest(pp, catch_failures: true)
+      end
+      it 'installs letsencrypt and nginx idempotently' do
+        apply_manifest(pp, catch_changes: true)
+      end
+
+    else
+      it 'fails to install' do
+        apply_manifest(pp, expect_failures: true)
+      end
+    end
+  end
+end

--- a/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper_acceptance'
 describe 'letsencrypt::plugin::nginx' do
   supported = case fact('os.family')
               when 'Debian'
-                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
-                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
+                true
               when 'RedHat'
                 true
               else

--- a/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::nginx' do
   supported = case fact('os.family')
-              when 'Debian'
-                true
               when 'RedHat'
                 true
               else

--- a/spec/classes/plugin/nginx_spec.rb
+++ b/spec/classes/plugin/nginx_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'letsencrypt::plugin::nginx' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} based operating systems" do
+      let(:facts) { facts }
+      let(:params) { {} }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'letsencrypt':
+          email => 'foo@example.com',
+        }
+        PUPPET
+      end
+      let(:package_name) do
+        case facts[:osfamily]
+        when 'Debian'
+          'python3-certbot-nginx'
+        when 'RedHat'
+          facts[:operatingsystem] == 'Fedora' ? 'python3-certbot-nginx' : 'python2-certbot-nginx'
+        end
+      end
+
+      context 'without required parameters' do
+        it { is_expected.not_to compile }
+      end
+
+      context 'with required parameters' do
+        it do
+          if package_name.nil?
+            is_expected.not_to compile
+          else
+            is_expected.to compile.with_all_deps
+          end
+        end
+
+        describe 'with manage_package => true' do
+          let(:params) { super().merge(manage_package: true) }
+
+          it do
+            if package_name.nil?
+              is_expected.not_to compile
+            else
+              is_expected.to contain_class('letsencrypt::plugin::nginx').with_package_name(package_name)
+              is_expected.to contain_package(package_name).with_ensure('installed')
+            end
+          end
+        end
+
+        describe 'with manage_package => false' do
+          let(:params) { super().merge(manage_package: false, package_name: 'nginx-package') }
+
+          it { is_expected.not_to contain_package('nginx-package') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/plugin/nginx_spec.rb
+++ b/spec/classes/plugin/nginx_spec.rb
@@ -14,8 +14,6 @@ describe 'letsencrypt::plugin::nginx' do
       end
       let(:package_name) do
         case facts[:osfamily]
-        when 'Debian'
-          'python3-certbot-nginx'
         when 'RedHat'
           facts[:operatingsystem] == 'Fedora' ? 'python3-certbot-nginx' : 'python2-certbot-nginx'
         end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -126,6 +126,26 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-rfc2136 --cert-name 'foo.example.com' -d 'foo.example.com' --dns-rfc2136-credentials /etc/letsencrypt/dns-rfc2136.ini --dns-rfc2136-propagation-seconds 10" }
       end
 
+      context 'with nginx plugin' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { plugin: 'nginx', letsencrypt_command: 'letsencrypt' } }
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'letsencrypt':
+            email      => 'foo@example.com',
+            config_dir => '/etc/letsencrypt',
+          }
+          class { 'letsencrypt::plugin::nginx':
+            package_name   => 'irrelevant',
+          }
+          PUPPET
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('letsencrypt::plugin::nginx') }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 --cert-name 'foo.example.com' -d 'foo.example.com'" }
+      end
+
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }


### PR DESCRIPTION
#### Pull Request (PR) description

I added automatic installation of the `...-certbot-nginx-...` package when `'plugin' => 'nginx'` is given to define `letsencrypt::certonly`. And i provided an example in Readme.

#### This Pull Request (PR) fixes the following issues

On Centos for example, when a Nginx web server is running, simply asking Certbot to create or renew certificates is not enough. It requires an additional package or plugin,