### PR TITLE
Add support for systemd service and timer units to renew.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The module can integrate with [puppet/epel](https://forge.puppetlabs.com/puppet/
 to set up the repo by setting the `configure_epel` parameter to `true` (the default for RedHat) and
 installing the module.
 
+For systemd support, [puppet/systemd](https://forge.puppet.com/modules/puppet/systemd) is required.
+
 ## Usage
 
 ### Setting up the Let's Encrypt client

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,10 @@ class letsencrypt (
   $renew_cron_hour                       = fqdn_rand(24),
   $renew_cron_minute                     = fqdn_rand(60, fqdn_rand_string(10)),
   $renew_cron_monthday                   = '*',
+  String[1] $renew_systemd_datespec      = 'daily',
+  Enum['cron', 'systemd'] $timer_type    = 'cron',
+  Boolean          $manage_firewalld     = false,
+  Array[String[1]] $manage_services      = [],
 ) {
   if $manage_install {
     contain letsencrypt::install # lint:ignore:relative_classname_inclusion

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
           'python3-certbot-dns-rfc2136'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
           'python3-certbot-dns-route53'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,4 +8,5 @@ configure_beaker do |host|
   when 'RedHat'
     host.install_package('crontabs')
   end
+  install_module_from_forge('puppet-systemd', '>= 2.6.0')
 end

--- a/templates/letsencrypt.service.epp
+++ b/templates/letsencrypt.service.epp
@@ -1,0 +1,9 @@
+# THIS FILE IS MANAGED BY PUPPET
+[Unit]
+Description=Let's Encrypt renewal
+
+[Service]
+Type=oneshot
+ExecStart=<%= $letsencrypt::renew::command %> <% if $letsencrypt::renew::manage_firewalld { -%>--pre-hook "firewall-cmd --add-service=https && firewall-cmd --add-service=http" <% } -%> --post-hook "<% if $letsencrypt::renew::manage_services { -%>
+<% $letsencrypt::renew::manage_services.each |$service| { -%>
+service <%= $service %> restart && <% } -%>true<% if $letsencrypt::renew::manage_services and $letsencrypt::renew::manage_firewalld { -%> && <% } -%><% } -%><%if $letsencrypt::renew::manage_firewalld { -%>firewall-cmd --remove-service=https && firewall-cmd --remove-service=http<% } -%>"

--- a/templates/letsencrypt.timer.epp
+++ b/templates/letsencrypt.timer.epp
@@ -1,0 +1,12 @@
+# THIS FILE IS MANAGED BY PUPPET
+[Unit]
+Description=Daily renewal of Let's Encrypt's certificates
+
+[Timer]
+OnCalendar=<%= $letsencrypt::renew::renew_systemd_datespec %>
+RandomizedDelaySec=1day
+Persistent=true
+Unit=letsencrypt.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This also adds support for naming services to restart with systemd instead of long-handing it all.
It also adds support for managing firewalls using firewalld for systems that are not meant to be http/https accessible at all times.

These three are essentially the same support and it is difficult to break it up

Again, I would love help knowing quite how to create the CI acceptances for this.