### PR TITLE
Raise upper bound version of stdlib & vcsrepo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "puppetlabs/inifile",
@@ -78,7 +78,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
#### Pull Request (PR) description

As new versions of `stdlib` and `vcsrepo` have been released, this PR updates `metadata.json` to their latest version

(Any feedback would be greatly appreciated :) )

#### This Pull Request (PR) fixes the following issues

(none)