### PR TITLE
use ACME API v2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class letsencrypt::params {
   $cron_scripts_path   = "${facts['puppet_vardir']}/letsencrypt" # path for renewal scripts called by cron
   $version             = 'v0.30.2'
   $config              = {
-    'server' => 'https://acme-v01.api.letsencrypt.org/directory',
+    'server' => 'https://acme-v02.api.letsencrypt.org/directory',
   }
 
   if $facts['osfamily'] == 'Debian' {

--- a/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
@@ -16,7 +16,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
       class { 'letsencrypt' :
         email  => 'letsregister@example.com',
         config => {
-          'server' => 'https://acme-staging.api.letsencrypt.org/directory',
+          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
         },
       }
       class { 'letsencrypt::plugin::dns_rfc2136':

--- a/spec/acceptance/letsencrypt_spec.rb
+++ b/spec/acceptance/letsencrypt_spec.rb
@@ -6,7 +6,7 @@ describe 'letsencrypt' do
       class { 'letsencrypt' :
         email  => 'letsregister@example.com',
         config => {
-          'server' => 'https://acme-staging.api.letsencrypt.org/directory',
+          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
         },
       }
     )
@@ -23,7 +23,7 @@ describe 'letsencrypt' do
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode 644 }
-      its(:content) { is_expected.to match %r{server = https://acme-staging.api.letsencrypt.org/directory} }
+      its(:content) { is_expected.to match %r{server = https://acme-staging-v02.api.letsencrypt.org/directory} }
       its(:content) { is_expected.to match %r{email = letsregister@example.com} }
     end
   end
@@ -34,7 +34,7 @@ describe 'letsencrypt' do
         install_method => 'vcs',
         email          => 'letsregister@example.com',
         config         => {
-          'server' => 'https://acme-staging.api.letsencrypt.org/directory',
+          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
         },
       }
     )
@@ -51,7 +51,7 @@ describe 'letsencrypt' do
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode 644 }
-      its(:content) { is_expected.to match %r{server = https://acme-staging.api.letsencrypt.org/directory} }
+      its(:content) { is_expected.to match %r{server = https://acme-staging-v02.api.letsencrypt.org/directory} }
       its(:content) { is_expected.to match %r{email = letsregister@example.com} }
     end
 

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -48,7 +48,7 @@ describe 'letsencrypt' do
 
             if facts[:osfamily] == 'FreeBSD'
               is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini email foo@example.com')
-              is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory')
+              is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory')
               is_expected.to contain_file('letsencrypt-renewal-hooks-puppet').
                 with(ensure: 'directory',
                      path: '/usr/local/etc/letsencrypt/renewal-hooks-puppet',
@@ -59,7 +59,7 @@ describe 'letsencrypt' do
                      purge: true)
             else
               is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini email foo@example.com')
-              is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory')
+              is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory')
               is_expected.to contain_file('letsencrypt-renewal-hooks-puppet').with_path('/etc/letsencrypt/renewal-hooks-puppet')
             end
 
@@ -132,7 +132,7 @@ describe 'letsencrypt' do
         describe 'with custom config file' do
           let(:additional_params) { { config_file: '/etc/letsencrypt/custom_config.ini' } }
 
-          it { is_expected.to contain_ini_setting('/etc/letsencrypt/custom_config.ini server https://acme-v01.api.letsencrypt.org/directory') }
+          it { is_expected.to contain_ini_setting('/etc/letsencrypt/custom_config.ini server https://acme-v02.api.letsencrypt.org/directory') }
         end
 
         describe 'with custom config' do

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -23,12 +23,12 @@ describe 'letsencrypt::certonly' do
         if facts[:osfamily] == 'FreeBSD'
           it { is_expected.to contain_file('/usr/local/etc/letsencrypt') }
           it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini email foo@example.com') }
-          it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory') }
+          it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory') }
         else
           it { is_expected.to contain_file('/etc/letsencrypt') }
           it { is_expected.to contain_package('letsencrypt') } unless facts[:os]['release']['full'] == '14.04'
           it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini email foo@example.com') }
-          it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory') }
+          it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory') }
         end
         it { is_expected.to contain_exec('initialize letsencrypt') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
@@ -425,7 +425,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command %r{^certbot} }
         it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini email foo@example.com') }
-        it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v01.api.letsencrypt.org/directory') }
+        it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory') }
         it { is_expected.to contain_file('/usr/local/etc/letsencrypt').with_ensure('directory') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless '/usr/local/sbin/letsencrypt-domain-validation /usr/local/etc/letsencrypt/live/foo.example.com/cert.pem \'foo.example.com\'' }
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description


EOL plan for API V1 https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430

This PR permits to not have this message :
> The client lacks sufficient authorization :: Account creation on ACMEv1 is disabled. Please upgrade your ACME client to a version that supports ACMEv2 / RFC 8555. See https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430

Minimal required version is Certbot 0.22. The older version supported by this module should be from xenial that ship 0.23.

#### This Pull Request (PR) fixes the following issues

Fixes #196 

