### PR TITLE
allow to override --cert-name

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -48,6 +48,7 @@
 define letsencrypt::certonly (
   Enum['present','absent']                  $ensure               = 'present',
   Array[String[1]]                          $domains              = [$title],
+  Optional[String[1]]                       $cert_name            = $title,
   Boolean                                   $custom_plugin        = false,
   Letsencrypt::Plugin                       $plugin               = 'standalone',
   Array[Stdlib::Unixpath]                   $webroot_paths        = [],
@@ -95,14 +96,14 @@ define letsencrypt::certonly (
           "-d '${domain[0]}'"
         }
       }
-      $plugin_args = ["--cert-name '${title}'"] + $_plugin_args
+      $plugin_args = ["--cert-name '${cert_name}'"] + $_plugin_args
     }
 
     'dns-rfc2136': {
       require letsencrypt::plugin::dns_rfc2136
       $_domains = join($domains, '\' -d \'')
       $plugin_args = [
-        "--cert-name '${title}' -d",
+        "--cert-name '${cert_name}' -d",
         "'${_domains}'",
         "--dns-rfc2136-credentials ${letsencrypt::plugin::dns_rfc2136::config_dir}/dns-rfc2136.ini",
         "--dns-rfc2136-propagation-seconds ${letsencrypt::plugin::dns_rfc2136::propagation_seconds}",
@@ -112,9 +113,9 @@ define letsencrypt::certonly (
     default: {
       if $ensure == 'present' {
         $_domains = join($domains, '\' -d \'')
-        $plugin_args  = "--cert-name '${title}' -d '${_domains}'"
+        $plugin_args  = "--cert-name '${cert_name}' -d '${_domains}'"
       } else {
-        $plugin_args = "--cert-name '${title}'"
+        $plugin_args = "--cert-name '${cert_name}'"
       }
     }
   }
@@ -137,7 +138,7 @@ define letsencrypt::certonly (
   }
 
   # certbot uses --cert-name to generate the file path
-  $live_path_certname = regsubst($title, '^\*\.', '')
+  $live_path_certname = regsubst($cert_name, '^\*\.', '')
   $live_path = "${config_dir}/live/${live_path_certname}/cert.pem"
 
   $_command = flatten([

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -48,7 +48,7 @@
 define letsencrypt::certonly (
   Enum['present','absent']                  $ensure               = 'present',
   Array[String[1]]                          $domains              = [$title],
-  Optional[String[1]]                       $cert_name            = $title,
+  String[1]                                 $cert_name            = $title,
   Boolean                                   $custom_plugin        = false,
   Letsencrypt::Plugin                       $plugin               = 'standalone',
   Array[Stdlib::Unixpath]                   $webroot_paths        = [],

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -51,6 +51,14 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo' -d 'foo.example.com' -d 'bar.example.com' -d '*.example.com'" }
       end
 
+      context 'with custom cert-name' do
+        let(:title) { 'foo' }
+        let(:params) { { cert_name: 'bar.example.com' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'bar.example.com' -d 'foo'" }
+      end
+
       context 'with custom command' do
         let(:title) { 'foo.example.com' }
         let(:params) { { letsencrypt_command: '/usr/lib/letsencrypt/letsencrypt-auto' } }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add the possibility to choose a `$cert_name` parameter different from `$title`.

#### This Pull Request (PR) fixes the following issues

When the `$cert_name` vary with the `$title`, this prevents to use two resources to manage the same certificate, as in the following example:

```puppet
      # First standalone certificate is needed to create the key/certs, _before_ we can start apache with ssl enabled.
      ::letsencrypt::certonly {"${le_domains[0]}-standalone":
          domains     => $le_domains,
          manage_cron => false,
      }
      # this is the long-term cert, managing the cron renewal task
      -> ::letsencrypt::certonly {"${le_domains[0]}-webroot":
          domains              => $le_domains,
          manage_cron          => true,
          cron_success_command => 'apachectl -t && apachectl graceful',
          plugin               => 'webroot',
          webroot_paths        => [
            "/var/www/vhosts/${name}/htdocs",
          ],
      }
```

