### PR TITLE
#218 Switch to puppet-epel

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    epel: 'https://github.com/stahnma/puppet-module-epel.git'
+    epel: 'https://github.com/voxpupuli/puppet-epel.git'
     inifile: 'https://github.com/puppetlabs/puppetlabs-inifile.git'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     vcsrepo: 'https://github.com/puppetlabs/puppetlabs-vcsrepo.git'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ versions are defined in the [metadata.json](metadata.json)
 On EL (Red Hat, CentOS etc.) systems, the EPEL repository needs to be enabled
 for the Let's Encrypt client package.
 
-The module can integrate with [stahnma/epel](https://forge.puppetlabs.com/stahnma/epel)
+The module can integrate with [puppet/epel](https://forge.puppetlabs.com/puppet/epel)
 to set up the repo by setting the `configure_epel` parameter to `true` (the default for RedHat) and
 installing the module.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,7 +23,7 @@ _Private Classes_
 
 **Functions**
 
-* [`letsencrypt::letsencrypt_lookup`](#letsencryptletsencrypt_lookup): 
+* [`letsencrypt::letsencrypt_lookup`](#letsencryptletsencrypt_lookup):
 
 **Data types**
 
@@ -39,8 +39,6 @@ _Private Classes_
 Install and configure Certbot, the LetsEncrypt client
 
 #### Examples
-
-##### 
 
 ```puppet
 class { 'letsencrypt' :

--- a/metadata.json
+++ b/metadata.json
@@ -81,8 +81,8 @@
       "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "name": "puppet/epel",
+      "version_requirement": ">= 3.0.1 < 4.0.0"
     }
   ]
 }


### PR DESCRIPTION
As mentioned in #218 `stahnma-epel` has been transfered to voxpupuli. 

I left out `puppetlabs-inifile` < 6.0.0 as 5.x of this module is not released yet (current version is 4.1.0).

Fixes #218 