### PR TITLE
Ensure EPEL is configured before installing plugin

### DIFF
--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -24,6 +24,7 @@ class letsencrypt::plugin::dns_rfc2136 (
   Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
   Boolean $manage_package          = true,
 ) {
+  require letsencrypt
 
   if $manage_package {
     package { $package_name:
@@ -47,7 +48,6 @@ class letsencrypt::plugin::dns_rfc2136 (
     content => epp('letsencrypt/ini.epp', {
       vars => { '' => $ini_vars },
     }),
-    require => Class['letsencrypt'],
   }
 
 }


### PR DESCRIPTION
I've noticed other PRs fail because puppet is trying to install the
dns_rfc2136 package before EPEL has been configured. The cleanest way of
fixing this seems to be to have the plugin class `require letsencrypt`.
There are only two resources in `letsencrypt::plugin::dns_rfc2136`
and the `file` resource already required `Class['letsencrypt']`. Now the
`package` resource will too.

The base class already `contain`s `letsencrypt::install` and that
`include`s `epel` and configures the correct ordering.