### PR TITLE
add manifest to install dns-route53 plugin, along with tests

### DIFF
--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -1,3 +1,4 @@
 ---
 letsencrypt::configure_epel: true
 letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'

--- a/data/os/Debian/10.yaml
+++ b/data/os/Debian/10.yaml
@@ -1,2 +1,3 @@
 ---
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'

--- a/data/os/Fedora.yaml
+++ b/data/os/Fedora.yaml
@@ -1,3 +1,4 @@
 ---
 letsencrypt::configure_epel: false
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'

--- a/data/os/Ubuntu/18.04.yaml
+++ b/data/os/Ubuntu/18.04.yaml
@@ -1,2 +1,3 @@
 ---
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -110,6 +110,15 @@ define letsencrypt::certonly (
       ]
     }
 
+    'dns-route53': {
+        require letsencrypt::plugin::dns_route53
+        $_domains = join($domains, '\' -d \'')
+        $plugin_args  = [
+            "--cert-name '${cert_name}' -d '${_domains}'",
+            "--dns-route53-propagation-seconds ${letsencrypt::plugin::dns_route53::propagation_seconds}",
+        ]
+    }
+
     default: {
       if $ensure == 'present' {
         $_domains = join($domains, '\' -d \'')

--- a/manifests/plugin/dns_route53.pp
+++ b/manifests/plugin/dns_route53.pp
@@ -1,0 +1,22 @@
+# @summary Installs and configures the dns-route53 plugin
+#
+# This class installs and configures the Let's Encrypt dns-route53 plugin.
+# https://certbot-dns-route53.readthedocs.io
+#
+# @param propagation_seconds Number of seconds to wait for the DNS server to propagate the DNS-01 challenge.
+# @param manage_package Manage the plugin package.
+# @param package_name The name of the package to install when $manage_package is true.
+#
+class letsencrypt::plugin::dns_route53 (
+  String[1] $package_name,
+  Integer $propagation_seconds     = 10,
+  Boolean $manage_package          = true,
+) {
+  require letsencrypt
+
+  if $manage_package {
+    package { $package_name:
+      ensure => installed,
+    }
+  }
+}

--- a/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+
+describe 'letsencrypt::plugin::dns_route53' do
+  supported = case fact('os.family')
+              when 'Debian'
+                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
+                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
+              when 'RedHat'
+                true
+              else
+                false
+              end
+
+  context 'with defaults values' do
+    pp = <<-PUPPET
+      class { 'letsencrypt' :
+        email  => 'letsregister@example.com',
+        config => {
+          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
+        },
+      }
+      class { 'letsencrypt::plugin::dns_route53':
+      }
+    PUPPET
+
+    if supported
+      it 'installs letsencrypt and dns route53 plugin without error' do
+        apply_manifest(pp, catch_failures: true)
+      end
+      it 'installs letsencrypt and dns route53 idempotently' do
+        apply_manifest(pp, catch_changes: true)
+      end
+
+    else
+      it 'fails to install' do
+        apply_manifest(pp, expect_failures: true)
+      end
+    end
+  end
+end

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'letsencrypt::plugin::dns_route53' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} based operating systems" do
+      let(:facts) { facts }
+      let(:params) { {} }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'letsencrypt':
+          email => 'foo@example.com',
+        }
+        PUPPET
+      end
+      let(:package_name) do
+        osname = facts[:os]['name']
+        osrelease = facts[:os]['release']['major']
+        osfull = "#{osname}-#{osrelease}"
+        case osfull
+        when 'Debian-10', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+          'python3-certbot-dns-route53'
+        when 'RedHat-7', 'CentOS-7'
+          'python2-certbot-dns-route53'
+        end
+      end
+
+      context 'with required parameters' do
+        it do
+          if package_name.nil?
+            is_expected.not_to compile
+          else
+            is_expected.to compile.with_all_deps
+          end
+        end
+
+        describe 'with manage_package => true' do
+          let(:params) { super().merge(manage_package: true) }
+
+          it do
+            if package_name.nil?
+              is_expected.not_to compile
+            else
+              is_expected.to contain_class('letsencrypt::plugin::dns_route53').with_package_name(package_name)
+              is_expected.to contain_package(package_name).with_ensure('installed')
+            end
+          end
+        end
+
+        describe 'with manage_package => false' do
+          let(:params) { super().merge(manage_package: false, package_name: 'dns-route53-package') }
+
+          it { is_expected.not_to contain_package('dns-route53-package') }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -133,6 +133,26 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-rfc2136 --cert-name 'foo.example.com' -d 'foo.example.com' --dns-rfc2136-credentials /etc/letsencrypt/dns-rfc2136.ini --dns-rfc2136-propagation-seconds 10" }
       end
 
+      context 'with dns-route53 plugin' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { plugin: 'dns-route53', letsencrypt_command: 'letsencrypt' } }
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'letsencrypt':
+            email      => 'foo@example.com',
+            config_dir => '/etc/letsencrypt',
+          }
+          class { 'letsencrypt::plugin::dns_route53':
+            package_name   => 'irrelevant',
+          }
+          PUPPET
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('letsencrypt::plugin::dns_route53') }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-route53 --cert-name 'foo.example.com' -d 'foo.example.com' --dns-route53-propagation-seconds 10" }
+      end
+
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }


### PR DESCRIPTION
#### Pull Request (PR) description
The dns-route53 plugin was functional, but didn't manage the installation of the package. This creates a manifest to install it, along with tests.

I did not confirm the exact availability of every distribution - I assumed it would be available in the same versions that the dns-rfc2136 plugin is, so I copied that configuration. I have successfully tested these changes in our Centos7 environment.

This supports the only configuration option specific to that plugin, `--dns-route53-propagation-seconds`: https://certbot-dns-route53.readthedocs.io/en/stable/