### PR TITLE
Add sbin directories to PATH

### DIFF
--- a/templates/renew-script.sh.erb
+++ b/templates/renew-script.sh.erb
@@ -2,4 +2,5 @@
 <%- @execution_environment.each do |environment| -%>
 export <%= environment %>
 <%- end -%>
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 <%= @cron_cmd %>


### PR DESCRIPTION
At least on Debian nginx and apache2 are in /usr/sbin, which is not in the default cron PATH