### PR TITLE
Allow setting file group owner

### DIFF
--- a/data/OpenBSD-family.yaml
+++ b/data/OpenBSD-family.yaml
@@ -1,3 +1,3 @@
 ---
 letsencrypt::cron_owner_group: 'wheel'
-letsencrypt::root_file_owner_group: 'root'
+letsencrypt::root_file_owner_group: 'wheel'

--- a/data/OpenBSD-family.yaml
+++ b/data/OpenBSD-family.yaml
@@ -1,2 +1,3 @@
 ---
 letsencrypt::cron_owner_group: 'wheel'
+letsencrypt::root_file_owner_group: 'root'

--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -5,10 +5,12 @@
 # @param type Hook type.
 # @param hook_file Path to deploy hook script.
 # @param commands Bash commands to execute when the hook is run by certbot.
+# @param hook_file_group Group owner of the hook file
 #
 define letsencrypt::hook (
   Enum['pre', 'post', 'deploy'] $type,
   String[1]                     $hook_file,
+  String                        $hook_file_group = $letsencrypt::root_file_owner_group,
   # hook.sh.epp will validate this
   Variant[String[1],Array[String[1]]] $commands,
 ) {
@@ -20,7 +22,7 @@ define letsencrypt::hook (
   file { $hook_file:
     ensure  => file,
     owner   => 'root',
-    group   => 'root',
+    group   => $hook_file_group,
     mode    => '0755',
     content => epp('letsencrypt/hook.sh.epp', {
         commands     => $commands,

--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -9,10 +9,10 @@
 #
 define letsencrypt::hook (
   Enum['pre', 'post', 'deploy'] $type,
-  String[1]                     $hook_file,
-  String                        $hook_file_group = $letsencrypt::root_file_owner_group,
   # hook.sh.epp will validate this
   Variant[String[1],Array[String[1]]] $commands,
+  String[1]                     $hook_file,
+  String[1]                     $hook_file_group = $letsencrypt::root_file_owner_group,
 ) {
   $validate_env = $type ? {
     'deploy' => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@
 # @param config A hash representation of the letsencrypt configuration file.
 # @param cron_scripts_path The path for renewal scripts called by cron
 # @param cron_owner_group Group owner of cron renew scripts.
+# @param root_file_owner_group Group owner for the shipped files
 # @param manage_config A feature flag to toggle the management of the letsencrypt configuration file.
 # @param manage_install A feature flag to toggle the management of the letsencrypt client installation.
 # @param manage_dependencies A feature flag to toggle the management of the letsencrypt dependencies.
@@ -72,6 +73,7 @@ class letsencrypt (
   Hash $config                           = { 'server' => 'https://acme-v02.api.letsencrypt.org/directory' },
   String $cron_scripts_path              = "${facts['puppet_vardir']}/letsencrypt",
   String $cron_owner_group               = 'root',
+  String $root_file_owner_group          = 'root',
   Boolean $manage_config                 = true,
   Boolean $manage_install                = true,
   Boolean $manage_dependencies           = true,
@@ -124,7 +126,7 @@ class letsencrypt (
   file { '/usr/local/sbin/letsencrypt-domain-validation':
     ensure => file,
     owner  => 'root',
-    group  => 'root',
+    group  => $root_file_owner_group,
     mode   => '0500',
     source => "puppet:///modules/${module_name}/domain-validation.sh",
   }

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -12,6 +12,7 @@
 # @param manage_package Manage the plugin package.
 # @param package_name The name of the package to install when $manage_package is true.
 # @param config_dir The path to the configuration directory.
+# @param ini_file_owner_group Group owner of the generated ini file
 #
 class letsencrypt::plugin::dns_rfc2136 (
   Stdlib::Host $server,
@@ -23,6 +24,7 @@ class letsencrypt::plugin::dns_rfc2136 (
   Integer $propagation_seconds     = 10,
   Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
   Boolean $manage_package          = true,
+  String $ini_file_owner_group     = $letsencrypt::root_file_owner_group,
 ) {
   require letsencrypt
 

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -26,16 +26,19 @@
 # @param cron_monthday
 #   Optional string, integer or array of monthday(s) the renewal command should
 #   run. E.g. '2-30/2' to run on even days. Default: Every day.
+# @param hook_file_owner_group
+#   Set the group ownership of the pushed hook files
 #
 class letsencrypt::renew (
-  Variant[String[1], Array[String[1]]] $pre_hook_commands    = $letsencrypt::renew_pre_hook_commands,
-  Variant[String[1], Array[String[1]]] $post_hook_commands   = $letsencrypt::renew_post_hook_commands,
-  Variant[String[1], Array[String[1]]] $deploy_hook_commands = $letsencrypt::renew_deploy_hook_commands,
-  Array[String[1]]                     $additional_args      = $letsencrypt::renew_additional_args,
-  Enum['present', 'absent']            $cron_ensure          = $letsencrypt::renew_cron_ensure,
-  Letsencrypt::Cron::Hour              $cron_hour            = $letsencrypt::renew_cron_hour,
-  Letsencrypt::Cron::Minute            $cron_minute          = $letsencrypt::renew_cron_minute,
-  Letsencrypt::Cron::Monthday          $cron_monthday        = $letsencrypt::renew_cron_monthday,
+  Variant[String[1], Array[String[1]]] $pre_hook_commands     = $letsencrypt::renew_pre_hook_commands,
+  Variant[String[1], Array[String[1]]] $post_hook_commands    = $letsencrypt::renew_post_hook_commands,
+  Variant[String[1], Array[String[1]]] $deploy_hook_commands  = $letsencrypt::renew_deploy_hook_commands,
+  Array[String[1]]                     $additional_args       = $letsencrypt::renew_additional_args,
+  Enum['present', 'absent']            $cron_ensure           = $letsencrypt::renew_cron_ensure,
+  Letsencrypt::Cron::Hour              $cron_hour             = $letsencrypt::renew_cron_hour,
+  Letsencrypt::Cron::Minute            $cron_minute           = $letsencrypt::renew_cron_minute,
+  Letsencrypt::Cron::Monthday          $cron_monthday         = $letsencrypt::renew_cron_monthday,
+  String                               $hook_file_owner_group = $letsencrypt::root_file_owner_group,
 ) {
   # Directory used for Puppet-managed renewal hooks. Make sure old unmanaged
   # hooks in this directory are purged. Leave custom hooks in the default
@@ -44,7 +47,7 @@ class letsencrypt::renew (
     ensure  => directory,
     path    => "${letsencrypt::config_dir}/renewal-hooks-puppet",
     owner   => 'root',
-    group   => 'root',
+    group   => $hook_file_owner_group,
     mode    => '0755',
     recurse => true,
     purge   => true,

--- a/metadata.json
+++ b/metadata.json
@@ -7,58 +7,35 @@
   "source": "https://github.com/voxpupuli/puppet-letsencrypt",
   "project_page": "https://github.com/voxpupuli/puppet-letsencrypt",
   "issues_url": "https://github.com/voxpupuli/puppet-letsencrypt/issues",
-  "tags": [
-    "letsencrypt",
-    "let's encrypt",
-    "certbot",
-    "acme"
-  ],
+  "tags": ["letsencrypt", "let's encrypt", "certbot", "acme"],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystemrelease": ["7"]
     },
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystemrelease": ["7"]
     },
     {
       "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "30",
-        "31"
-      ]
+      "operatingsystemrelease": ["30", "31"]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04",
-        "18.04"
-      ]
+      "operatingsystemrelease": ["16.04", "18.04"]
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "9",
-        "10"
-      ]
+      "operatingsystemrelease": ["9", "10"]
     },
     {
       "operatingsystem": "OpenBSD",
-      "operatingsystemrelease": [
-        "6.2"
-      ]
+      "operatingsystemrelease": ["6.6", "6.7"]
     },
     {
       "operatingsystem": "FreeBSD",
-      "operatingsystemrelease": [
-        "11",
-        "12"
-      ]
+      "operatingsystemrelease": ["11", "12"]
     }
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
     {
       "operatingsystem": "OpenBSD",
       "operatingsystemrelease": [
-        "6.6"
+        "6.6",
         "6.7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,12 @@
   "source": "https://github.com/voxpupuli/puppet-letsencrypt",
   "project_page": "https://github.com/voxpupuli/puppet-letsencrypt",
   "issues_url": "https://github.com/voxpupuli/puppet-letsencrypt/issues",
-  "tags": ["letsencrypt", "let's encrypt", "certbot", "acme"],
+  "tags": [
+    "letsencrypt",
+    "let's encrypt",
+    "certbot",
+    "acme"
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-letsencrypt",
-  "version": "5.0.1-rc0",
+  "version": "6.0.1-rc0",
   "author": "Vox Pupuli",
   "summary": "Manages lets-encrypt and certbot + related certs",
   "license": "Apache-2.0",
@@ -16,31 +16,50 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": [
+        "7"
+      ]
     },
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": [
+        "7"
+      ]
     },
     {
       "operatingsystem": "Fedora",
-      "operatingsystemrelease": ["30", "31"]
+      "operatingsystemrelease": [
+        "30",
+        "31"
+      ]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": ["16.04", "18.04"]
+      "operatingsystemrelease": [
+        "16.04",
+        "18.04"
+      ]
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["9", "10"]
+      "operatingsystemrelease": [
+        "9",
+        "10"
+      ]
     },
     {
       "operatingsystem": "OpenBSD",
-      "operatingsystemrelease": ["6.6", "6.7"]
+      "operatingsystemrelease": [
+        "6.6"
+        "6.7"
+      ]
     },
     {
       "operatingsystem": "FreeBSD",
-      "operatingsystemrelease": ["11", "12"]
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Add new optional parameter to set the group ownership of shipped files

Some Operating Systems (a current OpenBSD release) don't have group 'root' - this PR allows setting the group  to something else.
Default of group:root has not changed

#### This Pull Request (PR) fixes the following issues
N/A
