### PR TITLE
Add Cloudflare DNS plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ letsencrypt::certonly { 'foo':
 }
 ```
 
+#### dns-cloudflare plugin
+
+To request a certificate using the `dns-cloudflare` plugin, you will at a minimum
+need to pass in either `api_token` or `api_key` and `email` for one of the
+authentication methods to the class `letsencrypt::plugin::dns_cloudflare`.
+Ideally the token secret should be encrypted, e.g. with eyaml if using Hiera.
+
+Plugin documentation and its parameters can be found here:
+https://certbot-dns-cloudflare.readthedocs.io
+
+Parameter defaults:
+
+- `config_path` ${letsencrypt::config_dir}/dns-cloudflare.ini
+- `propagation_seconds` 10
+
+Example:
+
+```puppet
+class { 'letsencrypt::plugin::dns_cloudflare':
+  api_token => 'cloudflare-api-token',
+}
+
+letsencrypt::certonly { 'foo':
+  domains => ['foo.example.com', 'bar.example.com'],
+  plugin  => 'dns-cloudflare',
+}
+```
+
 #### Additional arguments
 
 If you need to pass a command line flag to the `letsencrypt-auto` command that

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -2,3 +2,4 @@
 letsencrypt::configure_epel: true
 letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'python2-certbot-dns-cloudflare'

--- a/data/os/Debian/10.yaml
+++ b/data/os/Debian/10.yaml
@@ -1,3 +1,4 @@
 ---
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'python3-certbot-dns-cloudflare'

--- a/data/os/Fedora.yaml
+++ b/data/os/Fedora.yaml
@@ -2,3 +2,4 @@
 letsencrypt::configure_epel: false
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'python3-certbot-dns-cloudflare'

--- a/data/os/Ubuntu/18.04.yaml
+++ b/data/os/Ubuntu/18.04.yaml
@@ -1,3 +1,4 @@
 ---
 letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'python3-certbot-dns-cloudflare'

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -117,6 +117,17 @@ define letsencrypt::certonly (
       ]
     }
 
+    'dns-cloudflare': {
+      require letsencrypt::plugin::dns_cloudflare
+      $_domains = join($domains, '\' -d \'')
+      $plugin_args  = [
+        "--cert-name '${cert_name}' -d '${_domains}'",
+        '--dns-cloudflare',
+        "--dns-cloudflare-credentials ${letsencrypt::plugin::dns_cloudflare::config_path}",
+        "--dns-cloudflare-propagation-seconds ${letsencrypt::plugin::dns_cloudflare::propagation_seconds}",
+      ]
+    }
+
     default: {
       if $ensure == 'present' {
         $_domains = join($domains, '\' -d \'')

--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -1,0 +1,67 @@
+# @summary Installs and configures the dns-cloudflare plugin
+#
+# This class installs and configures the Let's Encrypt dns-cloudflare plugin.
+# https://certbot-dns-cloudflare.readthedocs.io
+#
+# @param package_name The name of the package to install when $manage_package is true.
+# @param api_key
+#   Optional string, cloudflare api key value for authentication.
+# @param api_token
+#   Optional string, cloudflare api token value for authentication.
+# @param email
+#   Optional string, cloudflare account email address, used in conjunction with api_key.
+# @param config_dir The path to the configuration directory.
+# @param manage_package Manage the plugin package.
+# @param propagation_seconds Number of seconds to wait for the DNS server to propagate the DNS-01 challenge.
+#
+class letsencrypt::plugin::dns_cloudflare (
+  Optional[String[1]] $package_name = undef,
+  Optional[String[1]] $api_key      = undef,
+  Optional[String[1]] $api_token    = undef,
+  Optional[String[1]] $email        = undef,
+  Stdlib::Absolutepath $config_path = "${letsencrypt::config_dir}/dns-cloudflare.ini",
+  Boolean $manage_package           = true,
+  Integer $propagation_seconds      = 10,
+) {
+  require letsencrypt
+
+  if ! $api_key and ! $api_token {
+    fail('No authentication method provided, please specify either api_token or api_key and api_email.')
+  }
+
+  if $manage_package {
+    if ! $package_name {
+      fail('No package name provided for certbot dns cloudflare plugin.')
+    }
+
+    package { $package_name:
+      ensure => installed,
+    }
+  }
+
+  if $api_token {
+    $ini_vars = {
+      dns_cloudflare_api_token => $api_token,
+    }
+  }
+  else {
+    if ! $email {
+      fail('Cloudflare email not provided for specified api_key.')
+    }
+
+    $ini_vars = {
+      dns_cloudflare_api_key => $api_key,
+      dns_cloudflare_email   => $email,
+    }
+  }
+
+  file { $config_path:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0400',
+    content => epp('letsencrypt/ini.epp', {
+        vars => { '' => $ini_vars },
+    }),
+  }
+}

--- a/spec/acceptance/letsencrypt_plugin_dns_cloudflare_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_cloudflare_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper_acceptance'
+
+describe 'letsencrypt::plugin::dns_cloudflare' do
+  supported = case fact('os.family')
+              when 'Debian'
+                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
+                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
+              when 'RedHat'
+                true
+              else
+                false
+              end
+
+  context 'with defaults values' do
+    pp = <<-PUPPET
+      class { 'letsencrypt' :
+        email  => 'letsregister@example.com',
+        config => {
+          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
+        },
+      }
+      class { 'letsencrypt::plugin::dns_cloudflare':
+        api_token => 'dummy-cloudflare-api-token',
+      }
+    PUPPET
+
+    if supported
+      it 'installs letsencrypt and dns cloudflare plugin without error' do
+        apply_manifest(pp, catch_failures: true)
+      end
+      it 'installs letsencrypt and dns cloudflare idempotently' do
+        apply_manifest(pp, catch_changes: true)
+      end
+
+    else
+      it 'fails to install' do
+        apply_manifest(pp, expect_failures: true)
+      end
+    end
+  end
+end

--- a/spec/classes/plugin/dns_cloudflare.rb
+++ b/spec/classes/plugin/dns_cloudflare.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'letsencrypt::plugin::dns_cloudflare' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} based operating systems" do
+      let(:facts) { facts }
+      let(:params) { {} }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'letsencrypt':
+          email => 'foo@example.com',
+        }
+        PUPPET
+      end
+      let(:package_name) do
+        osname = facts[:os]['name']
+        osrelease = facts[:os]['release']['major']
+        osfull = "#{osname}-#{osrelease}"
+        case osfull
+        when 'Debian-10', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+          'python3-certbot-dns-cloudflare'
+        when 'RedHat-7', 'CentOS-7'
+          'python2-certbot-dns-cloudflare'
+        end
+      end
+
+      context 'with required parameters' do
+        it do
+          if package_name.nil?
+            is_expected.not_to compile
+          else
+            is_expected.to compile.with_all_deps
+          end
+        end
+
+        describe 'with manage_package => true' do
+          let(:params) { super().merge(manage_package: true) }
+
+          it do
+            if package_name.nil?
+              is_expected.not_to compile
+            else
+              is_expected.to contain_class('letsencrypt::plugin::dns_cloudflare').with_package_name(package_name)
+              is_expected.to contain_package(package_name).with_ensure('installed')
+            end
+          end
+        end
+
+        describe 'with manage_package => false' do
+          let(:params) { super().merge(manage_package: false, package_name: 'dns-cloudflare-package') }
+
+          it { is_expected.not_to contain_package('dns-cloudflare-package') }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -153,6 +153,27 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-route53 --cert-name 'foo.example.com' -d 'foo.example.com' --dns-route53-propagation-seconds 10" }
       end
 
+      context 'with dns-cloudflare plugin' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { plugin: 'dns-cloudflare', letsencrypt_command: 'letsencrypt' } }
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'letsencrypt':
+            email      => 'foo@example.com',
+            config_dir => '/etc/letsencrypt',
+          }
+          class { 'letsencrypt::plugin::dns_cloudflare':
+            package_name => 'irrelevant',
+            api_token    => 'dummy-cloudflare-api-token',
+          }
+          PUPPET
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('letsencrypt::plugin::dns_cloudflare') }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-cloudflare --cert-name 'foo.example.com' -d 'foo.example.com' --dns-cloudflare --dns-cloudflare-credentials /etc/letsencrypt/dns-cloudflare.ini --dns-cloudflare-propagation-seconds 10" }
+      end
+
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }


### PR DESCRIPTION
#### Pull Request (PR) description

Adding feature support for the Certbot DNS Cloudflare plugin.

The plugin itself allows for two types of authentication, API token or Global API Key and corresponding Email so both are supported in this change.

Cloudflare recommends API tokens as they're more secure, so this module will prioritize token authentication over key authentication if both are provided.

#### This Pull Request (PR) fixes the following issues
n/a
