### PR TITLE
Fix certbot VCS package installation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,19 +70,19 @@ The path to the letsencrypt installation.
 
 Default value: '/opt/letsencrypt'
 
-##### `venv_path`
-
-Data type: `Any`
-
-virtualenv path for vcs-installed Certbot
-
-Default value: '/opt/letsencrypt/.venv'
-
 ##### `environment`
 
 Data type: `Array`
 
-An optional array of environment variables (in addition to VENV_PATH)
+An optional array of environment variables.
+
+Default value: []
+
+##### `vcs_dependencies`
+
+Data type: `Array`
+
+An array of packages on which the VCS installation method depends.
 
 Default value: []
 
@@ -100,7 +100,7 @@ Data type: `String`
 
 The Git ref (tag, sha, branch) to check out when installing the client with the `vcs` method.
 
-Default value: 'v0.39.0'
+Default value: 'v1.7.0'
 
 ##### `package_name`
 
@@ -381,6 +381,14 @@ Name of package to use when installing the client with the `package` method.
 
 Default value: $letsencrypt::package_name
 
+##### `vcs_dependencies`
+
+Data type: `Array`
+
+An array of packages on which the VCS installation method depends.
+
+Default value: []
+
 ### letsencrypt::plugin::dns_rfc2136
 
 This class installs and configures the Let's Encrypt dns-rfc2136 plugin.
@@ -613,7 +621,7 @@ Default value: []
 
 Data type: `Array[String[1]]`
 
-An optional array of environment variables (in addition to VENV_PATH).
+An optional array of environment variables.
 
 Default value: []
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,0 +1,5 @@
+---
+letsencrypt::vcs_dependencies:
+  - 'git'
+  - 'python3'
+  - 'python3-venv'

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -2,3 +2,7 @@
 letsencrypt::configure_epel: true
 letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'
+letsencrypt::vcs_dependencies:
+  - 'git'
+  - 'python3'
+  - 'python3-virtualenv'

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -17,7 +17,7 @@
 #   element will be used for all subsequent domains.
 # @param letsencrypt_command Command to run letsencrypt
 # @param additional_args An array of additional command line arguments to pass to the `letsencrypt-auto` command.
-# @param environment  An optional array of environment variables (in addition to VENV_PATH).
+# @param environment  An optional array of environment variables.
 # @param key_size Size for the RSA public key
 # @param manage_cron
 #   Indicating whether or not to schedule cron job for renewal.
@@ -157,7 +157,6 @@ define letsencrypt::certonly (
   ]).filter | $arg | { $arg =~ NotUndef and $arg != [] }
   $command = join($_command, ' ')
 
-  $execution_environment = ["VENV_PATH=${letsencrypt::venv_path}",] + $environment
   $verify_domains = join(unique($domains), '\' \'')
 
   if $ensure == 'present' {
@@ -170,7 +169,7 @@ define letsencrypt::certonly (
     command     => $command,
     *           => $exec_ensure,
     path        => $facts['path'],
-    environment => $execution_environment,
+    environment => $environment,
     provider    => 'shell',
     require     => [
       Class['letsencrypt'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,17 +105,22 @@ class letsencrypt (
 
   if $manage_config {
     contain letsencrypt::config # lint:ignore:relative_classname_inclusion
-    Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
+
+    if $install_method == 'vcs' {
+      Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
+    }
   }
 
   contain letsencrypt::renew
 
-  exec { 'initialize letsencrypt':
-    command     => 'python3 tools/venv3.py',
-    cwd         => $path,
-    path        => $facts['path'],
-    environment => $environment,
-    refreshonly => true,
+  if $install_method == 'vcs' {
+    exec { 'initialize letsencrypt':
+      command     => 'python3 tools/venv3.py',
+      cwd         => $path,
+      path        => $facts['path'],
+      environment => $environment,
+      refreshonly => true,
+    }
   }
 
   # Used in letsencrypt::certonly Exec["letsencrypt certonly ${title}"]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class letsencrypt (
   Boolean $manage_config                 = true,
   Boolean $manage_install                = true,
   Boolean $manage_dependencies           = true,
-  Array[String] $vcs_dependencies        = [],
+  Array[String[1]] $vcs_dependencies     = [],
   Enum['package', 'vcs'] $install_method = 'package',
   Boolean $agree_tos                     = true,
   Boolean $unsafe_registration           = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@
 # @param path The path to the letsencrypt installation.
 # @param repo A Git URL to install the Let's encrypt client from.
 # @param version The Git ref (tag, sha, branch) to check out when installing the client with the `vcs` method.
+# @param vcs_dependencies Array of packages to install before executing vcs installation.
 # @param package_ensure The value passed to `ensure` when installing the client with the `package` method.
 # @param package_name Name of package to use when installing the client with the `package` method.
 #
@@ -20,12 +21,12 @@ class letsencrypt::install (
   String $path                           = $letsencrypt::path,
   String $repo                           = $letsencrypt::repo,
   String $version                        = $letsencrypt::version,
+  Array[String] $vcs_dependencies        = $letsencrypt::vcs_dependencies,
 ) {
   if $install_method == 'vcs' {
     if $manage_dependencies {
-      $dependencies = ['python', 'git']
-      ensure_packages($dependencies)
-      Package[$dependencies] -> Vcsrepo[$path]
+      ensure_packages($vcs_dependencies)
+      Package[$vcs_dependencies] -> Vcsrepo[$path]
     }
 
     vcsrepo { $path:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,7 +21,7 @@ class letsencrypt::install (
   String $path                           = $letsencrypt::path,
   String $repo                           = $letsencrypt::repo,
   String $version                        = $letsencrypt::version,
-  Array[String] $vcs_dependencies        = $letsencrypt::vcs_dependencies,
+  Array[String[1]] $vcs_dependencies     = $letsencrypt::vcs_dependencies,
 ) {
   if $install_method == 'vcs' {
     if $manage_dependencies {

--- a/spec/acceptance/letsencrypt_spec.rb
+++ b/spec/acceptance/letsencrypt_spec.rb
@@ -55,7 +55,7 @@ describe 'letsencrypt' do
       its(:content) { is_expected.to match %r{email = letsregister@example.com} }
     end
 
-    describe file('/opt/letsencrypt/.venv/bin/certbot') do
+    describe file('/opt/letsencrypt/venv3/bin/certbot') do
       it { is_expected.to be_file }
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -34,8 +34,7 @@ describe 'letsencrypt' do
                    repo: 'https://github.com/certbot/certbot.git',
                    version: 'v1.7.0').
               that_comes_before('Class[letsencrypt::renew]')
-            is_expected.to contain_exec('initialize letsencrypt')
-            is_expected.to contain_class('letsencrypt::config').that_comes_before('Exec[initialize letsencrypt]')
+            is_expected.to contain_class('letsencrypt::config')
             is_expected.to contain_class('letsencrypt::renew').
               with(pre_hook_commands: [],
                    post_hook_commands: [],
@@ -94,6 +93,8 @@ describe 'letsencrypt' do
               is_expected.to contain_class('letsencrypt::install').with(install_method: 'vcs').
                 that_notifies('Exec[initialize letsencrypt]').
                 that_comes_before('Class[letsencrypt::renew]')
+              is_expected.to contain_exec('initialize letsencrypt')
+              is_expected.to contain_class('letsencrypt::config').that_comes_before('Exec[initialize letsencrypt]')
               is_expected.to contain_file('/etc/letsencrypt').with(ensure: 'directory')
             end
           end
@@ -107,7 +108,7 @@ describe 'letsencrypt' do
         end
 
         describe 'with custom environment variables' do
-          let(:additional_params) { { environment: ['FOO=bar', 'FIZZ=buzz'] } }
+          let(:additional_params) { { install_method: 'vcs', environment: ['FOO=bar', 'FIZZ=buzz'] } }
 
           it { is_expected.to contain_exec('initialize letsencrypt').with_environment(['FOO=bar', 'FIZZ=buzz']) }
         end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -29,7 +29,6 @@ describe 'letsencrypt::certonly' do
           it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini email foo@example.com') }
           it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory') }
         end
-        it { is_expected.to contain_exec('initialize letsencrypt') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless "/usr/local/sbin/letsencrypt-domain-validation #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem 'foo.example.com'" }
       end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -172,7 +172,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with hook' do
@@ -228,7 +228,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour(13).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -255,7 +255,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour('00').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and defined cron_hour (array)' do
@@ -269,7 +269,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_hour([1, 13]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and defined cron_minute (integer)' do
@@ -283,7 +283,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute(15).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and out of range defined cron_hour (integer)' do
@@ -310,7 +310,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute('15').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and defined cron_minute (array)' do
@@ -324,7 +324,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_minute([0, 30]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with manage_cron and ensure absent' do
@@ -354,7 +354,7 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt').with_ensure('directory') }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/tmp/custom_vardir/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with custom plugin and manage cron and cron_success_command' do
@@ -370,7 +370,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"' }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\n(echo before) && letsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com' && (echo success)\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\n(echo before) && letsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com' && (echo success)\n") }
       end
 
       context 'without plugin' do
@@ -401,7 +401,7 @@ describe 'letsencrypt::certonly' do
         let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'] } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_environment(['FOO=bar', 'FIZZ=buzz']) }
       end
 
       context 'with custom environment variables and manage_cron' do
@@ -409,7 +409,7 @@ describe 'letsencrypt::certonly' do
         let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n" }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n" }
       end
 
       context 'with manage cron and suppress_cron_output' do\
@@ -421,7 +421,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com' > /dev/null 2>&1\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com' > /dev/null 2>&1\n") }
       end
 
       context 'with manage cron and custom day of month' do
@@ -433,7 +433,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with(monthday: [1, 15]).with_ensure('present') }
-        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nexport VENV_PATH=/opt/letsencrypt/.venv\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
       end
 
       context 'with custom config_dir' do

--- a/templates/renew-script.sh.erb
+++ b/templates/renew-script.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
-<%- @execution_environment.each do |environment| -%>
+<%- @environment.each do |environment| -%>
 export <%= environment %>
 <%- end -%>
 <%= @cron_cmd %>


### PR DESCRIPTION
#### Pull Request (PR) description
As referenced in #240 the official installation method was changed
in December 2020, deprecating the use of the `certbot-auto` script,
and recommending `snap` as the primary package source.

As `snap` isn't yet a builtin package provider in Puppet and I don't
fancy creating a dependency on a third party module, nor do I want
to add a load of `exec` commands for managing snap packages I chose
to fix the VCS install method, and since it's used in the CI there's
less to change.

Since we can no longer use the `certbot-auto` script we should
follow the setup instructions provided by Letsencrypt's development
guide https://certbot.eff.org/docs/contributing.html.  Their guide
simply states to call a python script which configures the virtual
environment, and since the script is gone we no longer need the
VENV_PATH environment variable.

As the command needs to create a python virtual environment we
need to add the required package to the VCS dependencies, and from
testing I found there was no need to call the initialisation command
when installing from a package source, so I've made it conditional
to the VCS installation.

I've also taken the opportunity to update the version of `certbot`
that's checked out during VCS installation since `0.39.0` is now
around 1.5 years old.  Version `1.7.0` is the latest version that
is supported by Python 3.5 which is the lowest Python3 version
that's installed by default via package managers.

#### This Pull Request (PR) fixes the following issues
Fixes #240
