### PR TITLE
Add quote marks to class names in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install the Let's Encrypt client with the default configuration settings you
 must provide your email address to register with the Let's Encrypt servers:
 
 ```puppet
-class { letsencrypt:
+class { 'letsencrypt':
   email => 'foo@example.com',
 }
 ```
@@ -40,7 +40,7 @@ class { letsencrypt:
 If using Ubuntu16.04 with `install_method` to default `package`, you can enforce upgrade of package from 0.4 to 0.7 with :
 
 ```puppet
-class { letsencrypt:
+class { 'letsencrypt':
   email          => 'foo@example.com',
   package_ensure => 'latest',
 }
@@ -49,7 +49,7 @@ class { letsencrypt:
 If using EL7 without EPEL-preconfigured, add `configure_epel`:
 
 ```puppet
-class { letsencrypt:
+class { 'letsencrypt':
   configure_epel => true,
   email          => 'foo@example.com',
 }
@@ -64,7 +64,7 @@ the client.
 Alternatively, you can specify your email address in the $config hash:
 
 ```puppet
-class { letsencrypt:
+class { 'letsencrypt':
   config => {
     email  => 'foo@example.com',
     server => 'https://acme-v01.api.letsencrypt.org/directory',
@@ -79,7 +79,7 @@ If you don't wish to provide your email address, you can set the
 `unsafe_registration` parameter to `true` (this is not recommended):
 
 ```puppet
-class { letsencrypt:
+class { 'letsencrypt':
   unsafe_registration => true,
 }
 ```


### PR DESCRIPTION
#### Pull Request (PR) description
Add quote marks to the classes which don't have it in `README.md` to make the examples compliant with <http://puppet-lint.com/checks/unquoted_resource_title/>
