### PR TITLE
support for Ubuntu 20.04

### DIFF
--- a/data/os/Ubuntu/20.04.yaml
+++ b/data/os/Ubuntu/20.04.yaml
@@ -1,0 +1,3 @@
+---
+letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
           'python3-certbot-dns-rfc2136'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
           'python3-certbot-dns-route53'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When I added a Ubuntu 20.04 node to my puppet master, it could not find the package name for the DNS plugin. This fixed it.

This replaces PR https://github.com/voxpupuli/puppet-letsencrypt/pull/244#issue-624575233

#### This Pull Request (PR) fixes the following issues
