### PR TITLE
Add support for RHEL 8 and AlmaLinux 8

### DIFF
--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -1,4 +1,4 @@
 ---
 letsencrypt::configure_epel: true
-letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
-letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'
+letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'

--- a/data/os/CentOS/7.yaml
+++ b/data/os/CentOS/7.yaml
@@ -1,0 +1,3 @@
+---
+letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,0 +1,3 @@
+---
+letsencrypt::plugin::dns_rfc2136::package_name: 'python2-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'python2-certbot-dns-route53'

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,12 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7"
@@ -23,7 +29,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
           'python3-certbot-dns-rfc2136'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
           'python3-certbot-dns-route53'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for RHEL 8 and AlmaLinux 8.

I don't have an environment to actually test this in, but at least verified the package names are correct for EL8. Also, not sure if AlmaLinux can be added to the metadata/testing yet, but would be a nice to have. Is there a way to add RHEL 8 (Universal Base Image) and AlmaLinux 8 to the test matrix? However, I'm guessing that functionality would need to be added to [metadata2gha](https://github.com/voxpupuli/puppet_metadata) and possibly dependent projects?

Please let me know if you'd like to see any changes, thanks!

#### This Pull Request (PR) fixes the following issues
Fixes #236

