### PR TITLE
(#236) Enable python module stream on EL8

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,6 +64,7 @@ The following parameters are available in the `letsencrypt` class:
 * [`environment`](#environment)
 * [`package_name`](#package_name)
 * [`package_ensure`](#package_ensure)
+* [`dnfmodule_version`](#dnfmodule_version)
 * [`package_command`](#package_command)
 * [`config_file`](#config_file)
 * [`config`](#config)
@@ -118,6 +119,14 @@ Data type: `Any`
 The value passed to `ensure` when installing the client package.
 
 Default value: `'installed'`
+
+##### <a name="dnfmodule_version"></a>`dnfmodule_version`
+
+Data type: `String`
+
+The yum module stream version to enable on EL8 and greater variants using the `package` method with the `dnfmodule` provider.
+
+Default value: `'python36'`
 
 ##### <a name="package_command"></a>`package_command`
 
@@ -305,6 +314,7 @@ The following parameters are available in the `letsencrypt::install` class:
 * [`configure_epel`](#configure_epel)
 * [`package_ensure`](#package_ensure)
 * [`package_name`](#package_name)
+* [`dnfmodule_version`](#dnfmodule_version)
 
 ##### <a name="configure_epel"></a>`configure_epel`
 
@@ -329,6 +339,14 @@ Data type: `String`
 Name of package to use when installing the client package.
 
 Default value: `$letsencrypt::package_name`
+
+##### <a name="dnfmodule_version"></a>`dnfmodule_version`
+
+Data type: `String`
+
+The yum module stream version to enable on EL8 and greater variants using the `package` method with the `dnfmodule` provider.
+
+Default value: `$letsencrypt::dnfmodule_version`
 
 ### <a name="letsencryptplugindns_cloudflare"></a>`letsencrypt::plugin::dns_cloudflare`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@
 # @param environment An optional array of environment variables
 # @param package_name Name of package and command to use when installing the client package.
 # @param package_ensure The value passed to `ensure` when installing the client package.
+# @param dnfmodule_version The yum module stream version to enable on EL8 and greater variants using the `package` method with the `dnfmodule` provider.
 # @param package_command Path or name for letsencrypt executable.
 # @param config_file The path to the configuration file for the letsencrypt cli.
 # @param config A hash representation of the letsencrypt configuration file.
@@ -57,6 +58,7 @@ class letsencrypt (
   Array $environment                 = [],
   String $package_name               = 'certbot',
   $package_ensure                    = 'installed',
+  String[1] $dnfmodule_version           = 'python36',
   String $package_command            = 'certbot',
   Stdlib::Unixpath $config_dir       = '/etc/letsencrypt',
   String $config_file                = "${config_dir}/cli.ini",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,12 +3,23 @@
 # @param configure_epel A feature flag to include the 'epel' class and depend on it for package installation.
 # @param package_ensure The value passed to `ensure` when installing the client package.
 # @param package_name Name of package to use when installing the client package.
+# @param dnfmodule_version The yum module stream version to enable on EL8 and greater variants using the `package` method with the `dnfmodule` provider.
 #
 class letsencrypt::install (
   Boolean $configure_epel                = $letsencrypt::configure_epel,
   String $package_name                   = $letsencrypt::package_name,
   String $package_ensure                 = $letsencrypt::package_ensure,
+  String[1] $dnfmodule_version           = $letsencrypt::dnfmodule_version,
 ) {
+  if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
+    package { 'enable python module stream':
+      name        => $dnfmodule_version,
+      enable_only => true,
+      provider    => 'dnfmodule',
+      before      => Package['letsencrypt'],
+    }
+  }
+
   package { 'letsencrypt':
     ensure => $package_ensure,
     name   => $package_name,

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 6.15.0 < 8.0.0"
     }
   ],
   "dependencies": [

--- a/spec/classes/letsencrypt_install_spec.rb
+++ b/spec/classes/letsencrypt_install_spec.rb
@@ -9,7 +9,8 @@ describe 'letsencrypt::install' do
       {
         configure_epel: false,
         package_ensure: 'installed',
-        package_name: 'letsencrypt'
+        package_name: 'letsencrypt',
+        dnfmodule_version: 'python36'
       }
     end
     let(:additional_params) { {} }
@@ -43,6 +44,13 @@ describe 'letsencrypt::install' do
             is_expected.to contain_class('epel')
             is_expected.to contain_package('letsencrypt').that_requires('Class[epel]')
           end
+        end
+
+        case facts[:operatingsystemmajrelease]
+        when '7'
+          it { is_expected.not_to contain_package('enable python module stream').with_name('python36') }
+        when '8'
+          it { is_expected.to contain_package('enable python module stream').with_name('python36').with_enable_only('true').with_provider('dnfmodule') }
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
My apologies on missing this. In testing https://github.com/voxpupuli/puppet-letsencrypt/pull/254 I had manually enable the python36 module stream at some point before hand, but after running on a fresh install I realized certbot requires this module stream to be enabled per:
```
Error: Execution of '/bin/dnf -d 0 -e 1 -y install certbot' returned 1: Error:
 Problem: package certbot-1.20.0-1.el8.noarch requires python3-certbot = 1.20.0-1.el8, but none of the providers can be installed
  - package python3-certbot-1.20.0-1.el8.noarch requires /usr/bin/python3.6, but none of the providers can be installed
  - conflicting requests
  - package python36-3.6.8-2.module_el8.3.0+6191+6b4b10ec.x86_64 is filtered out by modular filtering
Error: /Stage[main]/Letsencrypt::Install/Package[letsencrypt]/ensure: change from 'purged' to 'present' failed: Execution of '/bin/dnf -d 0 -e 1 -y install certbot' returned 1: Error:
 Problem: package certbot-1.20.0-1.el8.noarch requires python3-certbot = 1.20.0-1.el8, but none of the providers can be installed
  - package python3-certbot-1.20.0-1.el8.noarch requires /usr/bin/python3.6, but none of the providers can be installed
  - conflicting requests
  - package python36-3.6.8-2.module_el8.3.0+6191+6b4b10ec.x86_64 is filtered out by modular filtering
```

#### This Pull Request (PR) fixes the following issues
Fixes #236
