### PR TITLE
dns_rfc2136_spec, dns_route53_spec: add Fedora 32, drop Fedora 30, 31

### DIFF
--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
           'python3-certbot-dns-rfc2136'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-30', 'Fedora-31'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
           'python3-certbot-dns-route53'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'


### PR DESCRIPTION
Support for Fedora 30 and 31 was removed in #235.