### PR TITLE
docs: wording updates due to removal of VCS install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ class { 'letsencrypt':
   }
 }
 ```
+
 During testing, you probably want to direct to the staging server instead with
 `server => 'https://acme-staging-v02.api.letsencrypt.org/directory'`
-
 
 If you don't wish to provide your email address, you can set the
 `unsafe_registration` parameter to `true` (this is not recommended):
@@ -169,7 +169,7 @@ letsencrypt::certonly { 'foo':
 
 #### Additional arguments
 
-If you need to pass a command line flag to the `letsencrypt-auto` command that
+If you need to pass a command line flag to the `certbot` command that
 is not supported natively by this module, you can use the `additional_args`
 parameter to pass those arguments:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,9 +14,9 @@
 #   The email address to use to register with Let's Encrypt. This takes
 #   precedence over an 'email' setting defined in $config.
 # @param environment An optional array of environment variables
-# @param package_name Name of package and command to use when installing the client with the `package` method.
-# @param package_ensure The value passed to `ensure` when installing the client with the `package` method.
-# @param package_command Path or name for letsencrypt executable when installing the client with the `package` method.
+# @param package_name Name of package and command to use when installing the client package.
+# @param package_ensure The value passed to `ensure` when installing the client package.
+# @param package_command Path or name for letsencrypt executable.
 # @param config_file The path to the configuration file for the letsencrypt cli.
 # @param config A hash representation of the letsencrypt configuration file.
 # @param cron_scripts_path The path for renewal scripts called by cron

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 # @summary Installs the Let's Encrypt client.
 #
-# @param configure_epel  A feature flag to include the 'epel' class and depend on it for package installation.
-# @param package_ensure The value passed to `ensure` when installing the client with the `package` method.
-# @param package_name Name of package to use when installing the client with the `package` method.
+# @param configure_epel A feature flag to include the 'epel' class and depend on it for package installation.
+# @param package_ensure The value passed to `ensure` when installing the client package.
+# @param package_name Name of package to use when installing the client package.
 #
 class letsencrypt::install (
   Boolean $configure_epel                = $letsencrypt::configure_epel,


### PR DESCRIPTION
init.pp, install.pp: Referring to the "package method" doesn't make sense now that that's the only method since commit ee77abc6ea9ca114f8fec382522abfe56571daef removed the VCS install method.

README.md: the command that comes in packages is `certbot`, not `letsencrypt-auto`.