### PR TITLE
add puppetlabs-cron_core as dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,10 @@
       "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
+      "name": "puppetlabs-cron_core",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
       "name": "puppet/epel",
       "version_requirement": ">= 3.0.1 < 4.0.0"
     }


### PR DESCRIPTION
Since minimal version of Puppet is 6, the core modules have to be declared as a dependency
