### PR TITLE
depend on puppetlabs-cron_core

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -85,6 +85,10 @@
     {
       "name": "puppet/epel",
       "version_requirement": ">= 3.0.1 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/cron_core",
+      "version_requirement": ">= 1.1.0 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description
`puppetlabs-cron_core` is listed in the [`.fixtures.yml`](https://github.com/voxpupuli/puppet-letsencrypt/blob/master/.fixtures.yml#L9-L11) but not in the `metadata.json`. 
The `puppetlabs-cron_core` module is used in [`cron.pp`](https://github.com/voxpupuli/puppet-letsencrypt/blob/master/manifests/renew.pp#L79-L86).

#### This Pull Request (PR) fixes the following issues
All modules that this module depends on, should be listed in the `metadata.json`.

### Note
I don't know if the version I chose, is appropriate. Any suggestions?