### PR TITLE
Drop obsolete operating system version check in acceptance tests

### DIFF
--- a/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::dns_rfc2136' do
-  supported = case fact('os.family')
-              when 'Debian'
-                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
-                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
-              when 'RedHat'
-                true
-              else
-                false
-              end
-
   context 'with defaults values' do
     pp = <<-PUPPET
       class { 'letsencrypt' :
@@ -26,24 +16,18 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
       }
     PUPPET
 
-    if supported
-      it 'installs letsencrypt and dns rfc2136 plugin without error' do
-        apply_manifest(pp, catch_failures: true)
-      end
-      it 'installs letsencrypt and dns rfc2136 idempotently' do
-        apply_manifest(pp, catch_changes: true)
-      end
+    it 'installs letsencrypt and dns rfc2136 plugin without error' do
+      apply_manifest(pp, catch_failures: true)
+    end
+    it 'installs letsencrypt and dns rfc2136 idempotently' do
+      apply_manifest(pp, catch_changes: true)
+    end
 
-      describe file('/etc/letsencrypt/dns-rfc2136.ini') do
-        it { is_expected.to be_file }
-        it { is_expected.to be_owned_by 'root' }
-        it { is_expected.to be_grouped_into 'root' }
-        it { is_expected.to be_mode 400 }
-      end
-    else
-      it 'fails to install' do
-        apply_manifest(pp, expect_failures: true)
-      end
+    describe file('/etc/letsencrypt/dns-rfc2136.ini') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+      it { is_expected.to be_mode 400 }
     end
   end
 end

--- a/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::dns_route53' do
-  supported = case fact('os.family')
-              when 'Debian'
-                # Debian 9 has it in backports, Ubuntu started shipping in Bionic
-                fact('os.release.major') != '9' && fact('os.release.major') != '16.04'
-              when 'RedHat'
-                true
-              else
-                false
-              end
-
   context 'with defaults values' do
     pp = <<-PUPPET
       class { 'letsencrypt' :
@@ -23,18 +13,11 @@ describe 'letsencrypt::plugin::dns_route53' do
       }
     PUPPET
 
-    if supported
-      it 'installs letsencrypt and dns route53 plugin without error' do
-        apply_manifest(pp, catch_failures: true)
-      end
-      it 'installs letsencrypt and dns route53 idempotently' do
-        apply_manifest(pp, catch_changes: true)
-      end
-
-    else
-      it 'fails to install' do
-        apply_manifest(pp, expect_failures: true)
-      end
+    it 'installs letsencrypt and dns route53 plugin without error' do
+      apply_manifest(pp, catch_failures: true)
+    end
+    it 'installs letsencrypt and dns route53 idempotently' do
+      apply_manifest(pp, catch_changes: true)
     end
   end
 end


### PR DESCRIPTION
Debian 9 and Ubuntu 16.04 are not supported by this plugin, so therefore
this check is obsolete.
Fixes: https://github.com/voxpupuli/puppet-letsencrypt/commit/415b8827101d6e473d8fb667b0426ea2a8731608