### PR TITLE
create certificates from class parameter (hiera)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,6 +73,7 @@ The following parameters are available in the `letsencrypt` class:
 * [`unsafe_registration`](#unsafe_registration)
 * [`config_dir`](#config_dir)
 * [`key_size`](#key_size)
+* [`certificates`](#certificates)
 * [`renew_pre_hook_commands`](#renew_pre_hook_commands)
 * [`renew_post_hook_commands`](#renew_post_hook_commands)
 * [`renew_deploy_hook_commands`](#renew_deploy_hook_commands)
@@ -208,6 +209,14 @@ Data type: `Integer[2048]`
 Size for the RSA public key
 
 Default value: `4096`
+
+##### <a name="certificates"></a>`certificates`
+
+Data type: `Hash[String[1],Hash]`
+
+A hash containing certificates. Each key is the title and each value is a hash, both passed to letsencrypt::certonly.
+
+Default value: `{}`
 
 ##### <a name="renew_pre_hook_commands"></a>`renew_pre_hook_commands`
 

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -141,6 +141,18 @@ describe 'letsencrypt' do
           it { is_expected.to contain_file('/foo/bar/baz').with(ensure: 'directory') }
         end
 
+        describe 'with list of certificates' do
+          let(:additional_params) do
+            { certificates: {
+              'foo' => { 'domains' => %w[lth0edae4nzfq895 nsgqqm4mbw257t9i] },
+              'a' => { 'environment' => %w[ABC=y9jby5nmfgmstnbk DFE=y00lt0fh1vj2amjx] }
+            } }
+          end
+
+          it { is_expected.to contain_letsencrypt__certonly('foo').with_domains(%w[lth0edae4nzfq895 nsgqqm4mbw257t9i]) }
+          it { is_expected.to contain_letsencrypt__certonly('a').with_environment(%w[ABC=y9jby5nmfgmstnbk DFE=y00lt0fh1vj2amjx]) }
+        end
+
         context 'when not agreeing to the TOS' do
           let(:params) { { agree_tos: false } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Support passing a hash of certificates from Hiera to the `letsencrypt` class.
This PR just iterates over the hash and creates `letsencrypt::certonly` for each entry.