### PR TITLE
Don't use reserved words

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class letsencrypt (
     source => "puppet:///modules/${module_name}/domain-validation.sh",
   }
 
-  $certificates.each |$title, $properties| {
-    letsencrypt::certonly { $title: * => $properties }
+  $certificates.each |$certificate, $properties| {
+    letsencrypt::certonly { $certificate: * => $properties }
   }
 }


### PR DESCRIPTION
$title is a reserved variable name and should not be used otherwise:
https://puppet.com/docs/puppet/7/lang_reserved.html#lang_reserved_words-reserved-variable-names