### PR TITLE
version 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v8.0.1](https://github.com/voxpupuli/puppet-letsencrypt/tree/v8.0.1) (2022-01-19)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-letsencrypt/compare/v8.0.0...v8.0.1)
+
+**Fixed bugs:**
+
+- Don't use reserved words [\#273](https://github.com/voxpupuli/puppet-letsencrypt/pull/273) ([nod0n](https://github.com/nod0n))
+
 ## [v8.0.0](https://github.com/voxpupuli/puppet-letsencrypt/tree/v8.0.0) (2022-01-19)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-letsencrypt/compare/v7.0.0...v8.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-letsencrypt",
-  "version": "8.0.1-rc0",
+  "version": "8.0.1",
   "author": "Vox Pupuli",
   "summary": "Manages lets-encrypt and certbot + related certs",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Fixed bugs:**

- Don't use reserved words [\#273](https://github.com/voxpupuli/puppet-letsencrypt/pull/273) ([nod0n](https://github.com/nod0n))