### PR TITLE
move scripts into a separate class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,6 +18,7 @@
 #### Private Classes
 
 * `letsencrypt::config`: Configures the Let's Encrypt client.
+* `letsencrypt::scripts`: Deploy helper scripts scripts
 
 ### Defined types
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -252,7 +252,7 @@ define letsencrypt::certonly (
     environment => $environment,
     provider    => 'shell',
     require     => [
-      Class['letsencrypt'],
+      Exec['initialize letsencrypt'],
       File['/usr/local/sbin/letsencrypt-domain-validation'],
     ],
   }

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -141,6 +141,8 @@ define letsencrypt::certonly (
     fail("The 'webroot_paths' parameter must be specified when using the 'webroot' plugin")
   }
 
+  include letsencrypt::scripts
+
   # Wildcard-less title for use in file paths
   $title_nowc = regsubst($title, '^\*\.', '')
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,6 @@ class letsencrypt (
   }
 
   contain letsencrypt::renew
-  include letsencrypt::scripts
 
   # TODO: do we need this command when installing from package?
   exec { 'initialize letsencrypt':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,7 @@ class letsencrypt (
   }
 
   contain letsencrypt::renew
+  include letsencrypt::scripts
 
   # TODO: do we need this command when installing from package?
   exec { 'initialize letsencrypt':
@@ -100,15 +101,6 @@ class letsencrypt (
     path        => $facts['path'],
     environment => $environment,
     refreshonly => true,
-  }
-
-  # Used in letsencrypt::certonly Exec["letsencrypt certonly ${title}"]
-  file { '/usr/local/sbin/letsencrypt-domain-validation':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0500',
-    source => "puppet:///modules/${module_name}/domain-validation.sh",
   }
 
   $certificates.each |$certificate, $properties| {

--- a/manifests/scripts.pp
+++ b/manifests/scripts.pp
@@ -1,0 +1,16 @@
+# @summary Deploy helper scripts scripts
+#
+# @api private
+#
+class letsencrypt::scripts () {
+  assert_private()
+
+  # required in letsencrypt::certonly
+  file { '/usr/local/sbin/letsencrypt-domain-validation':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0500',
+    content => file("${module_name}/domain-validation.sh"),
+  }
+}

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -19,13 +19,13 @@ describe 'letsencrypt' do
 
           epel = facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora'
 
-          it 'contains File[/usr/local/sbin/letsencrypt-domain-validation]' do
+          it 'contains the domain validation script' do
             is_expected.to contain_file('/usr/local/sbin/letsencrypt-domain-validation').
               with_ensure('file').
               with_owner('root').
               with_group('root').
               with_mode('0500').
-              with_source('puppet:///modules/letsencrypt/domain-validation.sh')
+              with_content(%r{result=}) # TODO: what should be check?
           end
 
           it 'contains the correct resources' do

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -25,7 +25,7 @@ describe 'letsencrypt' do
               with_owner('root').
               with_group('root').
               with_mode('0500').
-              with_content(%r{result=}) # TODO: what should be check?
+              with_content(%r{#!/bin/sh})
           end
 
           it 'contains the correct resources' do

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -151,6 +151,7 @@ describe 'letsencrypt' do
             } }
           end
 
+          it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_letsencrypt__certonly('foo').with_domains(%w[lth0edae4nzfq895 nsgqqm4mbw257t9i]) }
           it { is_expected.to contain_letsencrypt__certonly('a').with_environment(%w[ABC=y9jby5nmfgmstnbk DFE=y00lt0fh1vj2amjx]) }
         end

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -19,15 +19,6 @@ describe 'letsencrypt' do
 
           epel = facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora'
 
-          it 'contains the domain validation script' do
-            is_expected.to contain_file('/usr/local/sbin/letsencrypt-domain-validation').
-              with_ensure('file').
-              with_owner('root').
-              with_group('root').
-              with_mode('0500').
-              with_content(%r{#!/bin/sh})
-          end
-
           it 'contains the correct resources' do
             is_expected.to contain_class('letsencrypt::install').
               with(configure_epel: epel).

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -20,6 +20,17 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('Letsencrypt::Install') }
         it { is_expected.to contain_class('Letsencrypt::Config') }
+        it { is_expected.to contain_class('Letsencrypt::Scripts') }
+
+        # letsencrypt::scripts is a private class and is therefore tested in this define
+        it 'contains the domain validation script' do
+          is_expected.to contain_file('/usr/local/sbin/letsencrypt-domain-validation').
+            with_ensure('file').
+            with_owner('root').
+            with_group('root').
+            with_mode('0500').
+            with_content(%r{#!/bin/sh})
+        end
 
         if facts[:osfamily] == 'FreeBSD'
           it { is_expected.to contain_file('/usr/local/etc/letsencrypt') }


### PR DESCRIPTION
#### Pull Request (PR) description
letsencrypt::certonly required letsencrypt and when passing a
certificate list to $letsencrypt::certificates, it created a dependency
cycle.

This problem was discussed in slack: https://puppetcommunity.slack.com/archives/C0W1Y5VL0/p1642680497025900