### PR TITLE
Support logging cron output

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -22,7 +22,11 @@
 # @param manage_cron
 #   Indicating whether or not to schedule cron job for renewal.
 #   Runs daily but only renews if near expiration, e.g. within 10 days.
-# @param suppress_cron_output Redirect cron output to devnull
+# @param cron_output
+#   How to treat cron output
+#   `suppress` - Suppress all output
+#   `log` - Forward cron output to syslog
+#   undef - Do nothing with cron output (default)
 # @param cron_before_command Representation of a command that should be run before renewal command
 # @param cron_success_command Representation of a command that should be run if the renewal command succeeds.
 # @param cron_hour
@@ -57,7 +61,7 @@ define letsencrypt::certonly (
   Array[String[1]]                          $additional_args      = [],
   Array[String[1]]                          $environment          = [],
   Boolean                                   $manage_cron          = false,
-  Boolean                                   $suppress_cron_output = false,
+  Optional[Enum['suppress', 'log']]         $cron_output          = undef,
   Optional[String[1]]                       $cron_before_command  = undef,
   Optional[String[1]]                       $cron_success_command = undef,
   Array[Variant[Integer[0, 59], String[1]]] $cron_monthday        = ['*'],
@@ -182,11 +186,12 @@ define letsencrypt::certonly (
     $cron_script_ensure = $ensure ? { 'present' => 'file', default => 'absent' }
     $cron_ensure = $ensure
 
-    if $suppress_cron_output {
-      $croncommand = "${maincommand} > /dev/null 2>&1"
-    } else {
-      $croncommand = $maincommand
+    $croncommand = $cron_output ? {
+      'log'      => "${maincommand} 2>&1 | logger -t letsencrypt-renew",
+      'suppress' => "${maincommand} > /dev/null 2>&1",
+      default    => $maincommand
     }
+
     if $cron_before_command {
       $renewcommand = "(${cron_before_command}) && ${croncommand}"
     } else {

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -412,16 +412,28 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_content "#!/bin/sh\nexport FOO=bar\nexport FIZZ=buzz\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com'\n" }
       end
 
-      context 'with manage cron and suppress_cron_output' do\
+      context 'with manage cron and cron_output=suppress' do\
         let(:title) { 'foo.example.com' }
         let(:params) do
           { manage_cron: true,
-            suppress_cron_output: true }
+            cron_output: 'suppress' }
         end
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
         it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com' > /dev/null 2>&1\n") }
+      end
+
+      context 'with manage cron and cron_output=log' do\
+        let(:title) { 'foo.example.com' }
+        let(:params) do
+          { manage_cron: true,
+            cron_output: 'log' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\nletsencrypt --keep-until-expiring --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a standalone --cert-name 'foo.example.com' -d 'foo.example.com' 2>&1 | logger -t letsencrypt-renew\n") }
       end
 
       context 'with manage cron and custom day of month' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

Allow logging letsencrypt renewal output.  So far hoping this will be useful when post_commands don't fire, so debug what's going wrong there.
