### PR TITLE
Reduce acceptance test duplication

### DIFF
--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -1,0 +1,4 @@
+---
+letsencrypt::email: 'letsregister@example.com'
+letsencrypt::config:
+  server: 'https://acme-staging-v02.api.letsencrypt.org/directory'

--- a/spec/acceptance/letsencrypt_plugin_dns_cloudflare_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_cloudflare_spec.rb
@@ -6,12 +6,7 @@ describe 'letsencrypt::plugin::dns_cloudflare' do
   it_behaves_like 'an idempotent resource' do
     let(:manifest) do
       <<-PUPPET
-      class { 'letsencrypt' :
-        email  => 'letsregister@example.com',
-        config => {
-          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        },
-      }
+      include letsencrypt
       class { 'letsencrypt::plugin::dns_cloudflare':
         api_token => 'dummy-cloudflare-api-token',
       }

--- a/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_rfc2136_spec.rb
@@ -3,34 +3,23 @@
 require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::dns_rfc2136' do
-  context 'with defaults values' do
-    pp = <<-PUPPET
-      class { 'letsencrypt' :
-        email  => 'letsregister@example.com',
-        config => {
-          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        },
-      }
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      include letsencrypt
       class { 'letsencrypt::plugin::dns_rfc2136':
         server     => '192.0.2.1',
         key_name   => 'certbot',
         key_secret => 'secret',
       }
-    PUPPET
-
-    it 'installs letsencrypt and dns rfc2136 plugin without error' do
-      apply_manifest(pp, catch_failures: true)
+      PUPPET
     end
+  end
 
-    it 'installs letsencrypt and dns rfc2136 idempotently' do
-      apply_manifest(pp, catch_changes: true)
-    end
-
-    describe file('/etc/letsencrypt/dns-rfc2136.ini') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_owned_by 'root' }
-      it { is_expected.to be_grouped_into 'root' }
-      it { is_expected.to be_mode 400 }
-    end
+  describe file('/etc/letsencrypt/dns-rfc2136.ini') do
+    it { is_expected.to be_file }
+    it { is_expected.to be_owned_by 'root' }
+    it { is_expected.to be_grouped_into 'root' }
+    it { is_expected.to be_mode 400 }
   end
 end

--- a/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_dns_route53_spec.rb
@@ -3,24 +3,12 @@
 require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::dns_route53' do
-  context 'with defaults values' do
-    pp = <<-PUPPET
-      class { 'letsencrypt' :
-        email  => 'letsregister@example.com',
-        config => {
-          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        },
-      }
-      class { 'letsencrypt::plugin::dns_route53':
-      }
-    PUPPET
-
-    it 'installs letsencrypt and dns route53 plugin without error' do
-      apply_manifest(pp, catch_failures: true)
-    end
-
-    it 'installs letsencrypt and dns route53 idempotently' do
-      apply_manifest(pp, catch_changes: true)
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      include letsencrypt
+      include letsencrypt::plugin::dns_route53
+      PUPPET
     end
   end
 end

--- a/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_nginx_spec.rb
@@ -3,24 +3,12 @@
 require 'spec_helper_acceptance'
 
 describe 'letsencrypt::plugin::nginx' do
-  context 'with default values' do
-    pp = <<-PUPPET
-      class { 'letsencrypt' :
-        email  => 'letsregister@example.com',
-        config => {
-          'server' => 'https://acme-staging.api.letsencrypt.org/directory',
-        },
-      }
-      class { 'letsencrypt::plugin::nginx':
-      }
-    PUPPET
-
-    it 'installs letsencrypt and nginx plugin without error' do
-      apply_manifest(pp, catch_failures: true)
-    end
-
-    it 'installs letsencrypt and nginx idempotently' do
-      apply_manifest(pp, catch_changes: true)
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      include letsencrypt
+      include letsencrypt::plugin::nginx
+      PUPPET
     end
   end
 end

--- a/spec/acceptance/letsencrypt_spec.rb
+++ b/spec/acceptance/letsencrypt_spec.rb
@@ -4,21 +4,8 @@ require 'spec_helper_acceptance'
 
 describe 'letsencrypt' do
   context 'with defaults values' do
-    pp = %(
-      class { 'letsencrypt' :
-        email  => 'letsregister@example.com',
-        config => {
-          'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        },
-      }
-    )
-
-    it 'installs letsencrypt without error' do
-      apply_manifest(pp, catch_failures: true)
-    end
-
-    it 'installs letsencrypt idempotently' do
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) { 'include letsencrypt' }
     end
 
     describe file('/etc/letsencrypt/cli.ini') do


### PR DESCRIPTION
This uses Hiera in the acceptance tests to reduce duplication in the manifests. To reduce the spec duplications it uses a shared example provided by voxpupuli-acceptance.