### PR TITLE
Change the default `cron_hour` to twice a day

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -967,9 +967,9 @@ Default value: `undef`
 Data type: `Variant[Integer[0,23], String, Array]`
 
 Optional hour(s) that the renewal command should execute.
-e.g. '[0,12]' execute at midnight and midday.  Default - seeded random hour.
+e.g. '[0,12]' execute at midnight and midday.  Default - seeded random hour, twice a day.
 
-Default value: `fqdn_rand(24, $title)`
+Default value: `[fqdn_rand(12, $title), fqdn_rand(12, $title) + 12]`
 
 ##### <a name="-letsencrypt--certonly--cron_minute"></a>`cron_minute`
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -100,7 +100,7 @@
 # @param cron_success_command Representation of a command that should be run if the renewal command succeeds.
 # @param cron_hour
 #   Optional hour(s) that the renewal command should execute.
-#   e.g. '[0,12]' execute at midnight and midday.  Default - seeded random hour.
+#   e.g. '[0,12]' execute at midnight and midday.  Default - seeded random hour, twice a day.
 # @param cron_minute
 #   Optional minute(s) that the renewal command should execute.
 #   e.g. 0 or '00' or [0,30].  Default - seeded random minute.
@@ -136,7 +136,7 @@ define letsencrypt::certonly (
   Optional[String[1]]                       $cron_before_command  = undef,
   Optional[String[1]]                       $cron_success_command = undef,
   Array[Variant[Integer[0, 59], String[1]]] $cron_monthday        = ['*'],
-  Variant[Integer[0,23], String, Array]     $cron_hour            = fqdn_rand(24, $title),
+  Variant[Integer[0,23], String, Array]     $cron_hour            = [fqdn_rand(12, $title), fqdn_rand(12, $title) + 12],
   Variant[Integer[0,59], String, Array]     $cron_minute          = fqdn_rand(60, $title),
   Stdlib::Unixpath                          $config_dir           = $letsencrypt::config_dir,
   Variant[String[1], Array[String[1]]]      $pre_hook_commands    = $letsencrypt::certonly_pre_hook_commands,


### PR DESCRIPTION
#### Pull Request (PR) description
Change the random seed per hour for `letsencrypt::certonly` cronjob resource.

#### This Pull Request (PR) fixes the following issues
Fixes #47
