### PR TITLE
Add environment parameter to renew cron

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -85,6 +85,7 @@ The following parameters are available in the `letsencrypt` class:
 * [`renew_cron_hour`](#-letsencrypt--renew_cron_hour)
 * [`renew_cron_minute`](#-letsencrypt--renew_cron_minute)
 * [`renew_cron_monthday`](#-letsencrypt--renew_cron_monthday)
+* [`renew_cron_environment`](#-letsencrypt--renew_cron_environment)
 * [`certonly_pre_hook_commands`](#-letsencrypt--certonly_pre_hook_commands)
 * [`certonly_post_hook_commands`](#-letsencrypt--certonly_post_hook_commands)
 * [`certonly_deploy_hook_commands`](#-letsencrypt--certonly_deploy_hook_commands)
@@ -298,6 +299,15 @@ Optional string, integer or array of monthday(s) the renewal command should
 run. E.g. '2-30/2' to run on even days.
 
 Default value: `'*'`
+
+##### <a name="-letsencrypt--renew_cron_environment"></a>`renew_cron_environment`
+
+Data type: `Variant[String[1], Array[String[1]]]`
+
+Optional string or array of environments(s) the renewal command should have.
+E.g. PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+Default value: `[]`
 
 ##### <a name="-letsencrypt--certonly_pre_hook_commands"></a>`certonly_pre_hook_commands`
 
@@ -566,6 +576,7 @@ The following parameters are available in the `letsencrypt::renew` class:
 * [`cron_hour`](#-letsencrypt--renew--cron_hour)
 * [`cron_minute`](#-letsencrypt--renew--cron_minute)
 * [`cron_monthday`](#-letsencrypt--renew--cron_monthday)
+* [`cron_environment`](#-letsencrypt--renew--cron_environment)
 
 ##### <a name="-letsencrypt--renew--pre_hook_commands"></a>`pre_hook_commands`
 
@@ -638,6 +649,15 @@ Optional string, integer or array of monthday(s) the renewal command should
 run. E.g. '2-30/2' to run on even days. Default: Every day.
 
 Default value: `$letsencrypt::renew_cron_monthday`
+
+##### <a name="-letsencrypt--renew--cron_environment"></a>`cron_environment`
+
+Data type: `Variant[String[1], Array[String[1]]]`
+
+Optional string or array of environment variables the renewal command should have.
+E.g. PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+Default value: `$letsencrypt::renew_cron_environment`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,9 @@
 # @param renew_cron_monthday
 #   Optional string, integer or array of monthday(s) the renewal command should
 #   run. E.g. '2-30/2' to run on even days.
+# @param renew_cron_environment
+#   Optional string or array of environments(s) the renewal command should have.
+#   E.g. PATH=/sbin:/usr/sbin:/bin:/usr/bin
 # @param certonly_pre_hook_commands Array of commands to run in a shell before obtaining/renewing any certificates.
 # @param certonly_post_hook_commands Array of commands to run in a shell after attempting to obtain/renew certificates.
 # @param certonly_deploy_hook_commands
@@ -87,6 +90,7 @@ class letsencrypt (
   Letsencrypt::Cron::Hour $renew_cron_hour = fqdn_rand(24),
   Letsencrypt::Cron::Minute $renew_cron_minute = fqdn_rand(60),
   Letsencrypt::Cron::Monthday $renew_cron_monthday = '*',
+  Variant[String[1], Array[String[1]]] $renew_cron_environment = [],
   # define default hooks for all certonly defined resources
   Array[String[1]] $certonly_pre_hook_commands = [],
   Array[String[1]] $certonly_post_hook_commands = [],

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -26,6 +26,9 @@
 # @param cron_monthday
 #   Optional string, integer or array of monthday(s) the renewal command should
 #   run. E.g. '2-30/2' to run on even days. Default: Every day.
+# @param cron_environment
+#   Optional string or array of environment variables the renewal command should have.
+#   E.g. PATH=/sbin:/usr/sbin:/bin:/usr/bin
 #
 class letsencrypt::renew (
   Variant[String[1], Array[String[1]]] $pre_hook_commands    = $letsencrypt::renew_pre_hook_commands,
@@ -36,6 +39,7 @@ class letsencrypt::renew (
   Letsencrypt::Cron::Hour              $cron_hour            = $letsencrypt::renew_cron_hour,
   Letsencrypt::Cron::Minute            $cron_minute          = $letsencrypt::renew_cron_minute,
   Letsencrypt::Cron::Monthday          $cron_monthday        = $letsencrypt::renew_cron_monthday,
+  Variant[String[1], Array[String[1]]] $cron_environment     = $letsencrypt::renew_cron_environment,
 ) {
   # Directory used for Puppet-managed renewal hooks. Make sure old unmanaged
   # hooks in this directory are purged. Leave custom hooks in the default
@@ -77,11 +81,12 @@ class letsencrypt::renew (
   $command = join($_command, ' ')
 
   cron { 'letsencrypt-renew':
-    ensure   => $cron_ensure,
-    command  => $command,
-    user     => 'root',
-    hour     => $cron_hour,
-    minute   => $cron_minute,
-    monthday => $cron_monthday,
+    ensure      => $cron_ensure,
+    command     => $command,
+    user        => 'root',
+    hour        => $cron_hour,
+    minute      => $cron_minute,
+    monthday    => $cron_monthday,
+    environment => $cron_environment,
   }
 }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -215,6 +215,20 @@ describe 'letsencrypt' do
                      command: 'certbot renew -q AdditionalBar')
             end
           end
+
+          describe 'renew_cron_ensure and environment' do
+            let(:additional_params) do
+              { renew_cron_ensure: 'present',
+                renew_cron_environment: ['PATH=/usr/sbin'] }
+            end
+
+            it do
+              is_expected.to contain_cron('letsencrypt-renew').
+                with(ensure: 'present',
+                     command: 'certbot renew -q',
+                     environment: ['PATH=/usr/sbin'])
+            end
+          end
         end
       end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR add an option for adding environment to the global renew cron, this is useful for example with the nginx certbot plugin which somehow can't find nginx if the PATH in the cron doesn't include /usr/sbin.

This PR is similar to #189 which doesn't seem really active. 

#### This Pull Request (PR) fixes the following issues
Fixes: #250 (well kind of, it doesn't directly fix this, but it allows to add the PATH in the cron which will fix the problem).
