### PR TITLE
add option for removing cron job provided by distribution packages

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,6 +82,7 @@ The following parameters are available in the `letsencrypt` class:
 * [`renew_post_hook_commands`](#-letsencrypt--renew_post_hook_commands)
 * [`renew_deploy_hook_commands`](#-letsencrypt--renew_deploy_hook_commands)
 * [`renew_additional_args`](#-letsencrypt--renew_additional_args)
+* [`renew_disable_distro_cron`](#-letsencrypt--renew_disable_distro_cron)
 * [`renew_cron_ensure`](#-letsencrypt--renew_cron_ensure)
 * [`renew_cron_hour`](#-letsencrypt--renew_cron_hour)
 * [`renew_cron_minute`](#-letsencrypt--renew_cron_minute)
@@ -264,6 +265,14 @@ Data type: `Variant[String[1], Array[String[1]]]`
 Array of additional command line arguments to pass to 'certbot renew'.
 
 Default value: `[]`
+
+##### <a name="-letsencrypt--renew_disable_distro_cron"></a>`renew_disable_distro_cron`
+
+Data type: `Boolean`
+
+Boolean, set to true to disable the cron created by the distro package
+
+Default value: `false`
 
 ##### <a name="-letsencrypt--renew_cron_ensure"></a>`renew_cron_ensure`
 
@@ -635,6 +644,9 @@ The following parameters are available in the `letsencrypt::renew` class:
 * [`post_hook_commands`](#-letsencrypt--renew--post_hook_commands)
 * [`deploy_hook_commands`](#-letsencrypt--renew--deploy_hook_commands)
 * [`additional_args`](#-letsencrypt--renew--additional_args)
+* [`disable_distro_cron`](#-letsencrypt--renew--disable_distro_cron)
+* [`distro_renew_cron_file`](#-letsencrypt--renew--distro_renew_cron_file)
+* [`distro_renew_timer`](#-letsencrypt--renew--distro_renew_timer)
 * [`cron_ensure`](#-letsencrypt--renew--cron_ensure)
 * [`cron_hour`](#-letsencrypt--renew--cron_hour)
 * [`cron_minute`](#-letsencrypt--renew--cron_minute)
@@ -677,6 +689,30 @@ Data type: `Array[String[1]]`
 Array of additional command line arguments to pass to 'certbot renew'.
 
 Default value: `$letsencrypt::renew_additional_args`
+
+##### <a name="-letsencrypt--renew--disable_distro_cron"></a>`disable_distro_cron`
+
+Data type: `Boolean`
+
+Boolean, set to true to disable the cron created by the distro package
+
+Default value: `$letsencrypt::renew_disable_distro_cron`
+
+##### <a name="-letsencrypt--renew--distro_renew_cron_file"></a>`distro_renew_cron_file`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+Optional Unixpath, if set and if disable_distro_cron is true this file will be deleted (unless systemd is used)
+
+Default value: `undef`
+
+##### <a name="-letsencrypt--renew--distro_renew_timer"></a>`distro_renew_timer`
+
+Data type: `Optional[String]`
+
+Optional String, name of the systemd timer to disable if disable_distro_cron is true
+
+Default value: `undef`
 
 ##### <a name="-letsencrypt--renew--cron_ensure"></a>`cron_ensure`
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -3,3 +3,5 @@ letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'
 letsencrypt::plugin::dns_cloudflare::package_name: 'python3-certbot-dns-cloudflare'
 letsencrypt::plugin::dns_linode::package_name: 'python3-certbot-dns-linode'
+letsencrypt::renew::distro_renew_cron_file: /etc/cron.d/certbot
+letsencrypt::renew::distro_renew_timer: certbot.timer

--- a/data/FreeBSD-family.yaml
+++ b/data/FreeBSD-family.yaml
@@ -6,3 +6,4 @@ letsencrypt::plugin::dns_rfc2136::package_name: 'py311-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'py311-certbot-dns-route53'
 letsencrypt::plugin::dns_cloudflare::package_name: 'py311-certbot-dns-cloudflare'
 letsencrypt::plugin::dns_linode::package_name: 'py311-certbot-dns-linode'
+letsencrypt::renew::distro_renew_cron_file: /usr/local/etc/periodic/weekly/500.certbot-3.11

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -4,3 +4,4 @@ letsencrypt::plugin::dns_rfc2136::package_name: 'python3-certbot-dns-rfc2136'
 letsencrypt::plugin::dns_route53::package_name: 'python3-certbot-dns-route53'
 letsencrypt::plugin::dns_cloudflare::package_name: 'python3-certbot-dns-cloudflare'
 letsencrypt::plugin::dns_linode::package_name: 'python3-certbot-dns-linode'
+letsencrypt::renew::distro_renew_timer: certbot-renew.timer

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@
 #   - $RENEWED_DOMAINS: A space-delimited list of renewed certificate domains.
 #                       Example: "example.com www.example.com"
 # @param renew_additional_args Array of additional command line arguments to pass to 'certbot renew'.
+# @param renew_disable_distro_cron Boolean, set to true to disable the cron created by the distro package
 # @param renew_cron_ensure Intended state of the cron resource running certbot renew.
 # @param renew_cron_hour
 #   Optional string, integer or array of hour(s) the renewal command should run.
@@ -91,6 +92,7 @@ class letsencrypt (
   Letsencrypt::Cron::Minute $renew_cron_minute = fqdn_rand(60),
   Letsencrypt::Cron::Monthday $renew_cron_monthday = '*',
   Variant[String[1], Array[String[1]]] $renew_cron_environment = [],
+  Boolean                              $renew_disable_distro_cron = false,
   # define default hooks for all certonly defined resources
   Array[String[1]] $certonly_pre_hook_commands = [],
   Array[String[1]] $certonly_post_hook_commands = [],

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -16,6 +16,9 @@
 #   - $RENEWED_DOMAINS: A space-delimited list of renewed certificate domains.
 #                       Example: "example.com www.example.com"
 # @param additional_args Array of additional command line arguments to pass to 'certbot renew'.
+# @param disable_distro_cron Boolean, set to true to disable the cron created by the distro package
+# @param distro_renew_cron_file Optional Unixpath, if set and if disable_distro_cron is true this file will be deleted (unless systemd is used)
+# @param distro_renew_timer Optional String, name of the systemd timer to disable if disable_distro_cron is true
 # @param cron_ensure Intended state of the cron resource running certbot renew
 # @param cron_hour
 #   Optional string, integer or array of hour(s) the renewal command should run.
@@ -31,15 +34,18 @@
 #   E.g. PATH=/sbin:/usr/sbin:/bin:/usr/bin
 #
 class letsencrypt::renew (
-  Variant[String[1], Array[String[1]]] $pre_hook_commands    = $letsencrypt::renew_pre_hook_commands,
-  Variant[String[1], Array[String[1]]] $post_hook_commands   = $letsencrypt::renew_post_hook_commands,
-  Variant[String[1], Array[String[1]]] $deploy_hook_commands = $letsencrypt::renew_deploy_hook_commands,
-  Array[String[1]]                     $additional_args      = $letsencrypt::renew_additional_args,
-  Enum['present', 'absent']            $cron_ensure          = $letsencrypt::renew_cron_ensure,
-  Letsencrypt::Cron::Hour              $cron_hour            = $letsencrypt::renew_cron_hour,
-  Letsencrypt::Cron::Minute            $cron_minute          = $letsencrypt::renew_cron_minute,
-  Letsencrypt::Cron::Monthday          $cron_monthday        = $letsencrypt::renew_cron_monthday,
-  Variant[String[1], Array[String[1]]] $cron_environment     = $letsencrypt::renew_cron_environment,
+  Variant[String[1], Array[String[1]]] $pre_hook_commands      = $letsencrypt::renew_pre_hook_commands,
+  Variant[String[1], Array[String[1]]] $post_hook_commands     = $letsencrypt::renew_post_hook_commands,
+  Variant[String[1], Array[String[1]]] $deploy_hook_commands   = $letsencrypt::renew_deploy_hook_commands,
+  Array[String[1]]                     $additional_args        = $letsencrypt::renew_additional_args,
+  Enum['present', 'absent']            $cron_ensure            = $letsencrypt::renew_cron_ensure,
+  Letsencrypt::Cron::Hour              $cron_hour              = $letsencrypt::renew_cron_hour,
+  Letsencrypt::Cron::Minute            $cron_minute            = $letsencrypt::renew_cron_minute,
+  Letsencrypt::Cron::Monthday          $cron_monthday          = $letsencrypt::renew_cron_monthday,
+  Variant[String[1], Array[String[1]]] $cron_environment       = $letsencrypt::renew_cron_environment,
+  Boolean                              $disable_distro_cron    = $letsencrypt::renew_disable_distro_cron,
+  Optional[Stdlib::Unixpath]           $distro_renew_cron_file = undef,
+  Optional[String]                     $distro_renew_timer     = undef,
 ) {
   # Directory used for Puppet-managed renewal hooks. Make sure old unmanaged
   # hooks in this directory are purged. Leave custom hooks in the default
@@ -88,5 +94,18 @@ class letsencrypt::renew (
     minute      => $cron_minute,
     monthday    => $cron_monthday,
     environment => $cron_environment,
+  }
+
+  if $disable_distro_cron and $distro_renew_timer and $facts['service_provider'] == 'systemd' {
+    service { $distro_renew_timer:
+      ensure => stopped,
+      enable => false,
+    }
+  }
+  elsif $disable_distro_cron and $distro_renew_cron_file and $facts['service_provider'] != 'systemd' {
+    file { $distro_renew_cron_file:
+      ensure  => file,
+      content => '# certbot renew managed by puppet',
+    }
   }
 }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -202,6 +202,48 @@ describe 'letsencrypt' do
             end
           end
 
+          describe 'renew_cron_ensure and disable_distro_cron (with systemd)' do
+            let(:additional_params) do
+              { renew_cron_ensure: 'present',
+                renew_disable_distro_cron: true }
+            end
+            let(:facts) do
+              facts.merge({
+                            service_provider: 'systemd',
+                          })
+            end
+
+            it do
+              case facts['os']['family']
+              when 'RedHat'
+                is_expected.to contain_service('certbot-renew.timer').with(ensure: 'stopped', enable: false)
+              when 'Debian'
+                is_expected.to contain_service('certbot.timer').with(ensure: 'stopped', enable: false)
+              end
+            end
+          end
+
+          describe 'renew_cron_ensure and disable_distro_cron (without systemd)' do
+            let(:additional_params) do
+              { renew_cron_ensure: 'present',
+                renew_disable_distro_cron: true }
+            end
+            let(:facts) do
+              facts.merge({
+                            service_provider: 'init',
+                          })
+            end
+
+            it do
+              case facts['os']['family']
+              when 'Debian'
+                is_expected.to contain_file('/etc/cron.d/certbot')
+              when 'FreeBSD'
+                is_expected.to contain_file('/usr/local/etc/periodic/weekly/500.certbot-3.11')
+              end
+            end
+          end
+
           describe 'renew_cron_ensure and additional args' do
             let(:additional_params) do
               { renew_cron_ensure: 'present',


### PR DESCRIPTION
#### Pull Request (PR) description

This PR aims at removing the system cron or systemd timer when the renew cron is managed by puppet (this doesn't handle certonly cron). If we don't do that on certains distro (for exemple Debian), a cron will be automaticaly added by the package and might renew the certificate before the puppet cron, and thus the puppet renew hooks won't be executed.

#### This Pull Request (PR) fixes the following issues
Fixes #164
