### PR TITLE
Fix misuse of fqdn_rand_string

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -283,7 +283,7 @@ Data type: `Any`
 Optional string, integer or array of minute(s) the renewal command should
 run. E.g. 0 or '00' or [0,30].
 
-Default value: `fqdn_rand(60, fqdn_rand_string(10))`
+Default value: `fqdn_rand(60)`
 
 ##### <a name="renew_cron_monthday"></a>`renew_cron_monthday`
 
@@ -899,7 +899,7 @@ Data type: `Variant[Integer[0,59], String, Array]`
 Optional minute(s) that the renewal command should execute.
 e.g. 0 or '00' or [0,30].  Default - seeded random minute.
 
-Default value: `fqdn_rand(60, fqdn_rand_string(10, $title))`
+Default value: `fqdn_rand(60, $title)`
 
 ##### <a name="cron_monthday"></a>`cron_monthday`
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -131,7 +131,7 @@ define letsencrypt::certonly (
   Optional[String[1]]                       $cron_success_command = undef,
   Array[Variant[Integer[0, 59], String[1]]] $cron_monthday        = ['*'],
   Variant[Integer[0,23], String, Array]     $cron_hour            = fqdn_rand(24, $title),
-  Variant[Integer[0,59], String, Array]     $cron_minute          = fqdn_rand(60, fqdn_rand_string(10, $title)),
+  Variant[Integer[0,59], String, Array]     $cron_minute          = fqdn_rand(60, $title),
   Stdlib::Unixpath                          $config_dir           = $letsencrypt::config_dir,
   Variant[String[1], Array[String[1]]]      $pre_hook_commands    = [],
   Variant[String[1], Array[String[1]]]      $post_hook_commands   = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class letsencrypt (
   $renew_additional_args             = [],
   $renew_cron_ensure                 = 'absent',
   $renew_cron_hour                   = fqdn_rand(24),
-  $renew_cron_minute                 = fqdn_rand(60, fqdn_rand_string(10)),
+  $renew_cron_minute                 = fqdn_rand(60),
   $renew_cron_monthday               = '*',
 ) {
   if $manage_install {


### PR DESCRIPTION
#### Pull Request (PR) description
According to the puppetlabs-stdlib documentation,
fqdn_rand_string()'s second argument is the character set to use
when generating the random string, and its third argument is
the seed.  The certonly class incorrectly passes the domain name
as the second argument, causing fqdn_rand_string() to use the
host's fqdn as the seed, resulting in more-frequent-than-necessary
hash collisions.

#### This Pull Request (PR) fixes the following issues
(no issue)