### PR TITLE
Allow using the 'manual' plugin

### DIFF
--- a/types/plugin.pp
+++ b/types/plugin.pp
@@ -8,4 +8,5 @@ type Letsencrypt::Plugin = Enum[
   'dns-google',
   'dns-cloudflare',
   'dns-rfc2136',
+  'manual',
 ]


### PR DESCRIPTION
Adds `manual` as an allowed `plugin` value.

On a system I manage, I needed to run custom scripts during authentication.  With this change, I can use a config like this:
```puppet
letsencrypt::certonly { '…':
    plugin          => 'manual',
    additional_args => ['--manual-auth-hook …', '--manual-cleanup-hook …'],
    …
}
```

See also #89.
