### PR TITLE
Update FreeBSD package names

### DIFF
--- a/data/FreeBSD-family.yaml
+++ b/data/FreeBSD-family.yaml
@@ -1,7 +1,7 @@
 ---
-letsencrypt::package_name: 'py38-certbot'
+letsencrypt::package_name: 'py39-certbot'
 letsencrypt::config_dir: '/usr/local/etc/letsencrypt'
 letsencrypt::cron_owner_group: 'wheel'
-letsencrypt::plugin::dns_rfc2136::package_name: 'py38-certbot-dns-rfc2136'
-letsencrypt::plugin::dns_route53::package_name: 'py38-certbot-dns-route53'
-letsencrypt::plugin::dns_cloudflare::package_name: 'py38-certbot-dns-cloudflare'
+letsencrypt::plugin::dns_rfc2136::package_name: 'py39-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'py39-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'py39-certbot-dns-cloudflare'

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -76,9 +76,9 @@ describe 'letsencrypt' do
               is_expected.to contain_package('letsencrypt').with(name: 'certbot')
               is_expected.to contain_file('/etc/letsencrypt').with(ensure: 'directory')
             elsif facts[:operatingsystem] == 'FreeBSD'
-              is_expected.to contain_class('letsencrypt::install').with(package_name: 'py38-certbot')
+              is_expected.to contain_class('letsencrypt::install').with(package_name: 'py39-certbot')
               is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
-              is_expected.to contain_package('letsencrypt').with(name: 'py38-certbot')
+              is_expected.to contain_package('letsencrypt').with(name: 'py39-certbot')
               is_expected.to contain_file('/usr/local/etc/letsencrypt').with(ensure: 'directory')
             else
               is_expected.to contain_class('letsencrypt::install')

--- a/spec/classes/plugin/dns_cloudflare_spec.rb
+++ b/spec/classes/plugin/dns_cloudflare_spec.rb
@@ -23,7 +23,7 @@ describe 'letsencrypt::plugin::dns_cloudflare' do
         elsif %w[Debian RedHat].include?(facts[:os]['family'])
           'python3-certbot-dns-cloudflare'
         elsif %w[FreeBSD].include?(facts[:os]['family'])
-          'py38-certbot-dns-cloudflare'
+          'py39-certbot-dns-cloudflare'
         end
       end
 

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -24,7 +24,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'
         when 'FreeBSD-12', 'FreeBSD-13'
-          'py38-certbot-dns-rfc2136'
+          'py39-certbot-dns-rfc2136'
         end
       end
 

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -24,7 +24,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'
         when 'FreeBSD-12', 'FreeBSD-13'
-          'py38-certbot-dns-route53'
+          'py39-certbot-dns-route53'
         end
       end
 


### PR DESCRIPTION
FreeBSD ports now ship Python 3.9 by default:
https://cgit.freebsd.org/ports/commit/Mk/bsd.default-versions.mk?id=f117f2c48552792743a74a931a49e76fc4a9c0f7
