### PR TITLE
Add dns-azure to allowed plugins

### DIFF
--- a/spec/type_aliases/plugin_spec.rb
+++ b/spec/type_aliases/plugin_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'Letsencrypt::Plugin' do
-  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-route53', 'dns-google', 'dns-cloudflare', 'dns-rfc2136') }
+  it { is_expected.to allow_values('apache', 'standalone', 'webroot', 'nginx', 'dns-azure', 'dns-route53', 'dns-google', 'dns-cloudflare', 'dns-rfc2136') }
   it { is_expected.not_to allow_value(nil) }
   it { is_expected.not_to allow_value('foo') }
   it { is_expected.not_to allow_value('custom') }

--- a/types/plugin.pp
+++ b/types/plugin.pp
@@ -4,6 +4,7 @@ type Letsencrypt::Plugin = Enum[
   'standalone',
   'webroot',
   'nginx',
+  'dns-azure',
   'dns-route53',
   'dns-google',
   'dns-cloudflare',


### PR DESCRIPTION
#### Pull Request (PR) description

Add [dns-azure](https://github.com/terrycain/certbot-dns-azure) to list of allowed plugins. 

This is one of the 3rd party plugins listed at https://eff-certbot.readthedocs.io/en/stable/using.html#third-party-plugins

#### Caveat

I'm currently using this module on my branch on a RHEL 9 host, but the only caveat is the fastest way I found to get the plugin working was via the snap package:

```puppet
include snap

package { 'certbot':
  ensure          => installed,
  provider        => 'snap',
  install_options => ['classic'],
}

file { '/usr/bin/certbot':
  ensure  => link,
  source  => '/snap/bin/certbot',
  require => Package['certbot'],
}

package { 'certbot-dns-azure':
  ensure          => installed,
  provider        => 'snap',
  install_options => ['channel=edge'],
  require         => Package['certbot'],
}
```

And also had to run `snap set certbot trust-plugin-with-root=ok` before the last package resource, but didn't take the time yet to examine what changed on disk in order to create an exec resource to do that.