### PR TITLE
Drop Fedora 32, add Fedora 36 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "32"
+        "36"
       ]
     },
     {

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -19,7 +19,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-22.04', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-22.04', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-36'
           'python3-certbot-dns-rfc2136'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-rfc2136'

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -19,7 +19,7 @@ describe 'letsencrypt::plugin::dns_route53' do
         osrelease = facts[:os]['release']['major']
         osfull = "#{osname}-#{osrelease}"
         case osfull
-        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-22.04', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-32'
+        when 'Debian-10', 'Debian-11', 'AlmaLinux-8', 'RedHat-8', 'Ubuntu-22.04', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Fedora-36'
           'python3-certbot-dns-route53'
         when 'RedHat-7', 'CentOS-7'
           'python2-certbot-dns-route53'


### PR DESCRIPTION
Fedora 32 was EOL a while ago, so switch to latest "stable" release of Fedora.