### PR TITLE
Remove unnecessary exec

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -270,7 +270,6 @@ define letsencrypt::certonly (
     environment => $environment,
     provider    => 'shell',
     require     => [
-      Exec['initialize letsencrypt'],
       File['/usr/local/sbin/letsencrypt-domain-validation'],
     ],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,6 @@ class letsencrypt (
 ) {
   if $manage_install {
     contain letsencrypt::install # lint:ignore:relative_classname_inclusion
-    Class['letsencrypt::install'] ~> Exec['initialize letsencrypt']
     Class['letsencrypt::install'] -> Class['letsencrypt::renew']
   }
 
@@ -89,18 +88,9 @@ class letsencrypt (
 
   if $manage_config {
     contain letsencrypt::config # lint:ignore:relative_classname_inclusion
-    Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
   }
 
   contain letsencrypt::renew
-
-  # TODO: do we need this command when installing from package?
-  exec { 'initialize letsencrypt':
-    command     => "${package_command} -h",
-    path        => $facts['path'],
-    environment => $environment,
-    refreshonly => true,
-  }
 
   $certificates.each |$certificate, $properties| {
     letsencrypt::certonly { $certificate: * => $properties }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -22,10 +22,8 @@ describe 'letsencrypt' do
           it 'contains the correct resources' do
             is_expected.to contain_class('letsencrypt::install').
               with(configure_epel: epel).
-              that_notifies('Exec[initialize letsencrypt]').
               that_comes_before('Class[letsencrypt::renew]')
-            is_expected.to contain_exec('initialize letsencrypt').with_command('certbot -h')
-            is_expected.to contain_class('letsencrypt::config').that_comes_before('Exec[initialize letsencrypt]')
+            is_expected.to contain_class('letsencrypt::config')
             is_expected.to contain_class('letsencrypt::renew').
               with(pre_hook_commands: [],
                    post_hook_commands: [],
@@ -85,12 +83,6 @@ describe 'letsencrypt' do
               is_expected.to contain_file('/etc/letsencrypt').with(ensure: 'directory')
             end
           end
-        end
-
-        describe 'with custom environment variables' do
-          let(:additional_params) { { environment: ['FOO=bar', 'FIZZ=buzz'] } }
-
-          it { is_expected.to contain_exec('initialize letsencrypt').with_environment(['FOO=bar', 'FIZZ=buzz']) }
         end
 
         describe 'with custom package_ensure' do

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -42,7 +42,6 @@ describe 'letsencrypt::certonly' do
           it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini email foo@example.com') }
           it { is_expected.to contain_ini_setting('/etc/letsencrypt/cli.ini server https://acme-v02.api.letsencrypt.org/directory') }
         end
-        it { is_expected.to contain_exec('initialize letsencrypt') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_unless(['test ! -f /usr/local/sbin/letsencrypt-domain-validation', "/usr/local/sbin/letsencrypt-domain-validation #{pathprefix}/etc/letsencrypt/live/foo.example.com/cert.pem 'foo.example.com'"]) }
       end


### PR DESCRIPTION
Executing `letsencrypt -h` is not needed when installing binaries from a package.
