### PR TITLE
Add a `certbot_version` fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ letsencrypt::renew_deploy_hook_commands:
 
 ## Facts
 
+* [certbot_version](#fact-certbotversion)
+* [letsencrypt_directory](#fact-letsencryptdirectory)
+
+### Fact: certbot_version
+
+A fact that contains the current version of certbot installed on your operating system/distribution.
+
+### Fact: letsencrypt_directory
+
 Facts about your live certificates are available through facter. You can query the list of live certificates from puppet using `$::letsencrypt_directory` in your puppet code, hiera data or from the command line.
 
 ```

--- a/lib/facter/certbot_version.rb
+++ b/lib/facter/certbot_version.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Facter.add(:certbot_version) do
+  confine { Facter::Core::Execution.which('certbot') }
+
+  setcode do
+    output = Facter::Core::Execution.execute('certbot --version 2>/dev/null')
+    output[%r{^certbot (.*)$}, 1] if output
+  end
+end


### PR DESCRIPTION
#### This Pull Request (PR) adds the certbot version as a fact.

This fact can be used to add support for new certbot features while maintaining compatibility with older version.
Note that it does not take a custom `$package_command` into account.