### PR TITLE
convert merge() to stdlib::merge()

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class letsencrypt::config (
   }
 
   if $email {
-    $_config = merge($config, { 'email' => $email })
+    $_config = stdlib::merge($config, { 'email' => $email })
   } else {
     $_config = $config
   }


### PR DESCRIPTION
I needed one more change to make this running in my environment.

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, deprecation. merge. This function is deprecated, please use stdlib::merge instead. at ["/etc/puppetlabs/code/environments/production/forge/letsencrypt/manifests/config.pp", 27]
```

We still need to fix the CI tests. 