### PR TITLE
plugins: avoid circular dependencies

### DIFF
--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -23,7 +23,7 @@ class letsencrypt::plugin::dns_cloudflare (
   Boolean $manage_package           = true,
   Integer $propagation_seconds      = 10,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if ! $api_key and ! $api_token {
     fail('No authentication method provided, please specify either api_token or api_key and api_email.')

--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -34,8 +34,15 @@ class letsencrypt::plugin::dns_cloudflare (
       fail('No package name provided for certbot dns cloudflare plugin.')
     }
 
+    $requirement = if $letsencrypt::configure_epel {
+      Class['epel']
+    } else {
+      undef
+    }
+
     package { $package_name:
-      ensure => $letsencrypt::package_ensure,
+      ensure  => $letsencrypt::package_ensure,
+      require => $requirement,
     }
   }
 

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -24,7 +24,7 @@ class letsencrypt::plugin::dns_rfc2136 (
   Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
   Boolean $manage_package          = true,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:

--- a/manifests/plugin/dns_route53.pp
+++ b/manifests/plugin/dns_route53.pp
@@ -12,7 +12,7 @@ class letsencrypt::plugin::dns_route53 (
   Integer $propagation_seconds     = 10,
   Boolean $manage_package          = true,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -6,7 +6,7 @@ class letsencrypt::plugin::nginx (
   Boolean $manage_package = true,
   String[1] $package_name = 'python3-certbot-nginx',
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:


### PR DESCRIPTION
`include` the letsencrypt class instead of `require` it.

Fixes #331.
