### PR TITLE
move `letsencrypt::configure_epel` from hiera to `init.pp`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -184,6 +184,8 @@ Data type: `Boolean`
 
 A feature flag to include the 'epel' class and depend on it for package installation.
 
+Default value: `false`
+
 ##### <a name="-letsencrypt--agree_tos"></a>`agree_tos`
 
 Data type: `Boolean`

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,0 @@
----
-letsencrypt::configure_epel: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 #                       Example: "example.com www.example.com"
 #
 class letsencrypt (
-  Boolean $configure_epel,
+  Boolean $configure_epel            = false,
   Optional[String] $email            = undef,
   Array $environment                 = [],
   String $package_name               = 'certbot',

--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -23,7 +23,7 @@ class letsencrypt::plugin::dns_cloudflare (
   Boolean $manage_package           = true,
   Integer $propagation_seconds      = 10,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if ! $api_key and ! $api_token {
     fail('No authentication method provided, please specify either api_token or api_key and api_email.')

--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -34,8 +34,15 @@ class letsencrypt::plugin::dns_cloudflare (
       fail('No package name provided for certbot dns cloudflare plugin.')
     }
 
+    $requirement = if $letsencrypt::configure_epel {
+      Class['epel']
+    } else {
+      undef
+    }
+
     package { $package_name:
-      ensure => $letsencrypt::package_ensure,
+      ensure  => $letsencrypt::package_ensure,
+      require => $requirement,
     }
   }
 

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -24,7 +24,7 @@ class letsencrypt::plugin::dns_rfc2136 (
   Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
   Boolean $manage_package          = true,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:

--- a/manifests/plugin/dns_route53.pp
+++ b/manifests/plugin/dns_route53.pp
@@ -12,7 +12,7 @@ class letsencrypt::plugin::dns_route53 (
   Integer $propagation_seconds     = 10,
   Boolean $manage_package          = true,
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -6,7 +6,7 @@ class letsencrypt::plugin::nginx (
   Boolean $manage_package = true,
   String[1] $package_name = 'python3-certbot-nginx',
 ) {
-  require letsencrypt
+  include letsencrypt
 
   if $manage_package {
     package { $package_name:

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "36"
+        "39"
       ]
     },
     {


### PR DESCRIPTION
- plugins: avoid circular dependencies (#332)
- `plugin/dns_cloudflare`: require EPEL for package if needed (#332)
- `metadata.json`: Update supported Fedora version from 36 to 39 (#336)
- move `letsencrypt::configure_epel` from hiera to `init.pp`
