### PR TITLE
Update FreeBSD packages to Python 3.11

### DIFF
--- a/data/FreeBSD-family.yaml
+++ b/data/FreeBSD-family.yaml
@@ -1,7 +1,7 @@
 ---
-letsencrypt::package_name: 'py39-certbot'
+letsencrypt::package_name: 'py311-certbot'
 letsencrypt::config_dir: '/usr/local/etc/letsencrypt'
 letsencrypt::cron_owner_group: 'wheel'
-letsencrypt::plugin::dns_rfc2136::package_name: 'py39-certbot-dns-rfc2136'
-letsencrypt::plugin::dns_route53::package_name: 'py39-certbot-dns-route53'
-letsencrypt::plugin::dns_cloudflare::package_name: 'py39-certbot-dns-cloudflare'
+letsencrypt::plugin::dns_rfc2136::package_name: 'py311-certbot-dns-rfc2136'
+letsencrypt::plugin::dns_route53::package_name: 'py311-certbot-dns-route53'
+letsencrypt::plugin::dns_cloudflare::package_name: 'py311-certbot-dns-cloudflare'

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -74,9 +74,9 @@ describe 'letsencrypt' do
               is_expected.to contain_package('letsencrypt').with(name: 'certbot').with_ensure('installed')
               is_expected.to contain_file('/etc/letsencrypt').with(ensure: 'directory')
             elsif facts[:operatingsystem] == 'FreeBSD'
-              is_expected.to contain_class('letsencrypt::install').with(package_name: 'py39-certbot')
+              is_expected.to contain_class('letsencrypt::install').with(package_name: 'py311-certbot')
               is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
-              is_expected.to contain_package('letsencrypt').with(name: 'py39-certbot').with_ensure('installed')
+              is_expected.to contain_package('letsencrypt').with(name: 'py311-certbot').with_ensure('installed')
               is_expected.to contain_file('/usr/local/etc/letsencrypt').with(ensure: 'directory')
             else
               is_expected.to contain_class('letsencrypt::install')

--- a/spec/classes/plugin/dns_cloudflare_spec.rb
+++ b/spec/classes/plugin/dns_cloudflare_spec.rb
@@ -18,7 +18,7 @@ describe 'letsencrypt::plugin::dns_cloudflare' do
         if %w[Debian RedHat].include?(facts[:os]['family'])
           'python3-certbot-dns-cloudflare'
         elsif %w[FreeBSD].include?(facts[:os]['family'])
-          'py39-certbot-dns-cloudflare'
+          'py311-certbot-dns-cloudflare'
         end
       end
 

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
       let(:package_name) do
         case facts[:os]['family']
         when 'FreeBSD'
-          'py39-certbot-dns-rfc2136'
+          'py311-certbot-dns-rfc2136'
         when 'OpenBSD'
           ''
         else

--- a/spec/classes/plugin/dns_route53_spec.rb
+++ b/spec/classes/plugin/dns_route53_spec.rb
@@ -17,7 +17,7 @@ describe 'letsencrypt::plugin::dns_route53' do
       let(:package_name) do
         case facts[:os]['family']
         when 'FreeBSD'
-          'py39-certbot-dns-route53'
+          'py311-certbot-dns-route53'
         when 'OpenBSD'
           ''
         else


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Update FreeBSD packages to Python 3.11.

This has been the default since May 29th.

#### This Pull Request (PR) fixes the following issues
On FreeBSD 14, Python versions need to be manually specified, as `py39-` packages are no longer available. 