### PR TITLE
Remove EoL FreeBSD 12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "12",
         "13",
         "14"
       ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Remove FreeBSD 12 from metadata and test matrix.
Add FreeBSD 14 to test matrix.

#### This Pull Request (PR) fixes the following issues
n/a