### PR TITLE
remove the 'root' group and replace with group 0

### DIFF
--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -20,7 +20,7 @@ define letsencrypt::hook (
   file { $hook_file:
     ensure  => file,
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0755',
     content => epp('letsencrypt/hook.sh.epp', {
         commands     => $commands,

--- a/manifests/plugin/dns_cloudflare.pp
+++ b/manifests/plugin/dns_cloudflare.pp
@@ -65,7 +65,7 @@ class letsencrypt::plugin::dns_cloudflare (
   file { $config_path:
     ensure  => file,
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0400',
     content => epp('letsencrypt/ini.epp', {
         vars => { '' => $ini_vars },

--- a/manifests/plugin/dns_rfc2136.pp
+++ b/manifests/plugin/dns_rfc2136.pp
@@ -43,7 +43,7 @@ class letsencrypt::plugin::dns_rfc2136 (
   file { "${config_dir}/dns-rfc2136.ini":
     ensure  => file,
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0400',
     content => epp('letsencrypt/ini.epp', {
         vars => { '' => $ini_vars },

--- a/manifests/renew.pp
+++ b/manifests/renew.pp
@@ -48,7 +48,7 @@ class letsencrypt::renew (
     ensure  => directory,
     path    => "${letsencrypt::config_dir}/renewal-hooks-puppet",
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0755',
     recurse => true,
     purge   => true,

--- a/manifests/scripts.pp
+++ b/manifests/scripts.pp
@@ -9,7 +9,7 @@ class letsencrypt::scripts () {
   file { '/usr/local/sbin/letsencrypt-domain-validation':
     ensure  => file,
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0500',
     content => file("${module_name}/domain-validation.sh"),
   }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -40,7 +40,7 @@ describe 'letsencrypt' do
                 with(ensure: 'directory',
                      path: '/usr/local/etc/letsencrypt/renewal-hooks-puppet',
                      owner: 'root',
-                     group: 'root',
+                     group: 0,
                      mode: '0755',
                      recurse: true,
                      purge: true)

--- a/spec/classes/plugin/dns_rfc2136_spec.rb
+++ b/spec/classes/plugin/dns_rfc2136_spec.rb
@@ -55,7 +55,7 @@ describe 'letsencrypt::plugin::dns_rfc2136' do
             is_expected.to contain_file("#{pathprefix}/etc/letsencrypt/dns-rfc2136.ini").
               with_ensure('file').
               with_owner('root').
-              with_group('root').
+              with_group('0').
               with_mode('0400').
               with_content(%r{^.*dns_rfc2136_server.*$})
           end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -27,7 +27,7 @@ describe 'letsencrypt::certonly' do
           is_expected.to contain_file('/usr/local/sbin/letsencrypt-domain-validation').
             with_ensure('file').
             with_owner('root').
-            with_group('root').
+            with_group('0').
             with_mode('0500').
             with_content(%r{#!/bin/sh})
         end

--- a/spec/defines/letsencrypt_hook_spec.rb
+++ b/spec/defines/letsencrypt_hook_spec.rb
@@ -33,7 +33,7 @@ describe 'letsencrypt::hook' do
           is_expected.to contain_file('/etc/letsencrypt/renewal-hooks-puppet/foo.example.com-pre.sh').
             with(ensure: 'file',
                  owner: 'root',
-                 group: 'root',
+                 group: 0,
                  mode: '0755',
                  content: %r{^.*validate_env=0.*FooBar.*$}m).
             that_requires('File[letsencrypt-renewal-hooks-puppet]')


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Removes `group => 'root'` which breaks FreeBSD and OpenBSD. Much simpler than the previous approach.   Sorry for the PR churn.

Thanks to @bastelfreak for the suggestion.

#### This Pull Request (PR) fixes the following issues
Fixes #353 
Fixes #231 

