### PR TITLE
Add support for installing and configuring Certbot Apache plugin

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,7 @@
 #### Public Classes
 
 * [`letsencrypt`](#letsencrypt): Install and configure Certbot, the LetsEncrypt client
+* [`letsencrypt::plugin::apache`](#letsencrypt--plugin--apache): install and configure the Let's Encrypt apache plugin
 * [`letsencrypt::plugin::dns_cloudflare`](#letsencrypt--plugin--dns_cloudflare): Installs and configures the dns-cloudflare plugin
 * [`letsencrypt::plugin::dns_linode`](#letsencrypt--plugin--dns_linode): Installs and configures the dns-linode plugin
 * [`letsencrypt::plugin::dns_rfc2136`](#letsencrypt--plugin--dns_rfc2136): Installs and configures the dns-rfc2136 plugin
@@ -347,6 +348,33 @@ certificate. Two environmental variables are supplied by certbot:
                     Example: "example.com www.example.com"
 
 Default value: `[]`
+
+### <a name="letsencrypt--plugin--apache"></a>`letsencrypt::plugin::apache`
+
+install and configure the Let's Encrypt apache plugin
+
+#### Parameters
+
+The following parameters are available in the `letsencrypt::plugin::apache` class:
+
+* [`manage_package`](#-letsencrypt--plugin--apache--manage_package)
+* [`package_name`](#-letsencrypt--plugin--apache--package_name)
+
+##### <a name="-letsencrypt--plugin--apache--manage_package"></a>`manage_package`
+
+Data type: `Boolean`
+
+Manage the plugin package.
+
+Default value: `true`
+
+##### <a name="-letsencrypt--plugin--apache--package_name"></a>`package_name`
+
+Data type: `String[1]`
+
+The name of the package to install when $manage_package is true.
+
+Default value: `'python3-certbot-apache'`
 
 ### <a name="letsencrypt--plugin--dns_cloudflare"></a>`letsencrypt::plugin::dns_cloudflare`
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -226,6 +226,17 @@ define letsencrypt::certonly (
       }
     }
 
+    'apache': {
+      require letsencrypt::plugin::apache
+
+      if $ensure == 'present' {
+        $_domains = join($domains, '\' -d \'')
+        $plugin_args  = "--cert-name '${cert_name}' -d '${_domains}'"
+      } else {
+        $plugin_args = "--cert-name '${cert_name}'"
+      }
+    }
+
     default: {
       if $ensure == 'present' {
         $_domains = join($domains, '\' -d \'')

--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -1,0 +1,23 @@
+# @summary install and configure the Let's Encrypt apache plugin
+#
+# @param manage_package Manage the plugin package.
+# @param package_name The name of the package to install when $manage_package is true.
+class letsencrypt::plugin::apache (
+  Boolean $manage_package = true,
+  String[1] $package_name = 'python3-certbot-apache',
+) {
+  include letsencrypt
+
+  if $manage_package {
+    $requirement = if $letsencrypt::configure_epel {
+      Class['epel']
+    } else {
+      undef
+    }
+
+    package { $package_name:
+      ensure  => $letsencrypt::package_ensure,
+      require => $requirement,
+    }
+  }
+}

--- a/spec/acceptance/letsencrypt_plugin_apache_spec.rb
+++ b/spec/acceptance/letsencrypt_plugin_apache_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'letsencrypt::plugin::apache' do
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      include letsencrypt
+      include letsencrypt::plugin::apache
+      PUPPET
+    end
+  end
+end

--- a/spec/classes/plugin/apache_spec.rb
+++ b/spec/classes/plugin/apache_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'letsencrypt::plugin::apache' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) { {} }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'letsencrypt':
+          email => 'foo@example.com',
+        }
+        PUPPET
+      end
+      let(:package_name) do
+        'python3-certbot-apache'
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+
+        it 'installs the certbot apache plugin' do
+          is_expected.to contain_class('letsencrypt::plugin::apache')
+          is_expected.to contain_package(package_name).with_ensure('installed')
+        end
+
+        describe 'with manage_package => false' do
+          let(:params) { super().merge(manage_package: false, package_name: 'apache-package') }
+
+          it { is_expected.not_to contain_package('apache-package') }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -185,6 +185,26 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a nginx --cert-name 'foo.example.com' -d 'foo.example.com'" }
       end
 
+      context 'with apache plugin' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { plugin: 'apache', letsencrypt_command: 'letsencrypt' } }
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'letsencrypt':
+            email      => 'foo@example.com',
+            config_dir => '/etc/letsencrypt',
+          }
+          class { 'letsencrypt::plugin::apache':
+            package_name => 'irrelevant',
+          }
+          PUPPET
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('letsencrypt::plugin::apache') }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a apache --cert-name 'foo.example.com' -d 'foo.example.com'" }
+      end
+
       context 'with dns-cloudflare plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'dns-cloudflare', letsencrypt_command: 'letsencrypt' } }


### PR DESCRIPTION
#### Pull Request (PR) description

It was strange to me that the module mentions the apache plugin, but has no installation of said plugin anywhere.

In the meantime i used standalone and did an ugly cron pre/post combo But this should address the issue properly

* adds the plugin class 'apache'
* includes green tests.

