### PR TITLE
`.fixtures.yml`: remove `puppet` version constraint

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,5 @@ fixtures:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
-      puppet_version: ">= 6.0.0"
     cron_core:
       repo: https://github.com/puppetlabs/puppetlabs-cron_core.git
-      puppet_version: ">= 6.0.0"


### PR DESCRIPTION
This version constraint is not needed anymore.