### PR TITLE
Make compatible with `/bin/sh`, not all systems (FreeBSD) have `/bin/bash`

### DIFF
--- a/templates/hook.sh.epp
+++ b/templates/hook.sh.epp
@@ -2,7 +2,7 @@
   Variant[String[1], Array[String[1], 1]] $commands,
   Boolean $validate_env = false,
 | -%>
-#!/bin/bash
+#!/bin/sh
 # THIS FILE IS MANAGED BY PUPPET
 #
 # This script is intended to be used by certbot's hooks. The same simple Puppet
@@ -30,17 +30,17 @@ echo_err() {
 
 ### Begin script
 
-if [[ "$validate_env" -gt 0 ]]; then
+if [ "$validate_env" -gt 0 ]; then
   bork=0
-  if [[ -z "$RENEWED_DOMAINS" ]]; then
+  if [ -z "$RENEWED_DOMAINS" ]; then
     bork=1
     echo_err "Environment variable RENEWED_DOMAINS is empty"
   fi
-  if [[ -z "$RENEWED_LINEAGE" ]]; then
+  if [ -z "$RENEWED_LINEAGE" ]; then
     bork=1
     echo_err "Environment variable RENEWED_LINEAGE is empty"
   fi
-  [[ "$bork" -gt 0 ]] && exit 1
+  [ "$bork" -gt 0 ] && exit 1
 fi
 
 <% flatten([$commands]).each | $command | { -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The `hook.sh.epp` assumes /bin/bash, and uses bash style test operators (`[[` and `]]`)

It isn't strictly required, and all of it can be implemented with basic `/bin/sh` constructs too, which will allow the hooks to work on FreeBSD (and other unices that don't have bash as  /bin/bash)

#### This Pull Request (PR) fixes the following issues
No issue was filed for this PR, fix was directly implemented