### PR TITLE
lestencrypt::profiles: add new profile sdefines to support multiple config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,46 @@ class { 'letsencrypt':
 
 Create `letsencrypt::certonly` defines. See the `letsencrypt::certonly` examples in the REFERENCE.md for more details.
 
+### Using multiple ACME profiles
+
+You can define multiple Certbot configuration profiles with the `profiles` parameter and then choose which profile a certificate should use via the `profile` parameter on `letsencrypt::certonly`.
+
+This is useful when you need one profile for public certificates and another for internal/private CA certificates. The following example uses sectigo SCM
+
+```puppet
+class { 'letsencrypt':
+  email => 'pki-admin@example.com',
+  profiles => {
+    'public' => {
+      config => {
+        'email'        => 'pki-admin@example.com',
+        'server'       => 'https://acme.sectigo.com/v2/OV',
+        'eab-kid'      => '1',
+        'eab-hmac-key' => 'secret1',
+      },
+    },
+    'internal' => {
+      config => {
+        'email'        => 'pki-admin@example.com',
+        'server'       => 'https://acme.enterprise.sectigo.com',
+        'eab-kid'      => '2',
+        'eab-hmac-key' => 'secret2',
+      },
+    },
+  },
+}
+
+letsencrypt::certonly { 'www.example.com':
+  domains => ['www.example.com'],
+  profile => 'public',
+}
+
+letsencrypt::certonly { 'api.internal.example.com':
+  domains => ['api.internal.example.com'],
+  profile => 'internal',
+}
+```
+
 
 ### Renewing certificates
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,6 +27,7 @@
 
 * [`letsencrypt::certonly`](#letsencrypt--certonly): Request a certificate using the `certonly` installer
 * [`letsencrypt::hook`](#letsencrypt--hook): Creates hook scripts.
+* [`letsencrypt::profile`](#letsencrypt--profile): Defines a Let's Encrypt profile.
 
 ### Functions
 
@@ -69,6 +70,7 @@ The following parameters are available in the `letsencrypt` class:
 * [`package_command`](#-letsencrypt--package_command)
 * [`config_file`](#-letsencrypt--config_file)
 * [`config`](#-letsencrypt--config)
+* [`profiles`](#-letsencrypt--profiles)
 * [`cron_scripts_path`](#-letsencrypt--cron_scripts_path)
 * [`cron_owner_group`](#-letsencrypt--cron_owner_group)
 * [`manage_config`](#-letsencrypt--manage_config)
@@ -151,6 +153,14 @@ Data type: `Hash`
 A hash representation of the letsencrypt configuration file.
 
 Default value: `{ 'server' => 'https://acme-v02.api.letsencrypt.org/directory' }`
+
+##### <a name="-letsencrypt--profiles"></a>`profiles`
+
+Data type: `Hash`
+
+A hash of profiles. Each key is the title and each value is a hash, both passed to letsencrypt::profile.
+
+Default value: `{}`
 
 ##### <a name="-letsencrypt--cron_scripts_path"></a>`cron_scripts_path`
 
@@ -932,6 +942,7 @@ The following parameters are available in the `letsencrypt::certonly` defined ty
 * [`post_hook_commands`](#-letsencrypt--certonly--post_hook_commands)
 * [`deploy_hook_commands`](#-letsencrypt--certonly--deploy_hook_commands)
 * [`cert_name`](#-letsencrypt--certonly--cert_name)
+* [`profile`](#-letsencrypt--certonly--profile)
 
 ##### <a name="-letsencrypt--certonly--ensure"></a>`ensure`
 
@@ -1134,6 +1145,14 @@ the common name used for the certificate
 
 Default value: `$domains[0]`
 
+##### <a name="-letsencrypt--certonly--profile"></a>`profile`
+
+Data type: `String[1]`
+
+an optional profile to use for this certificate. If not specified, the default CLI profile will be used.
+
+Default value: `'cli'`
+
 ### <a name="letsencrypt--hook"></a>`letsencrypt::hook`
 
 This type is used by letsencrypt::renew and letsencrypt::certonly to create hook scripts.
@@ -1163,6 +1182,33 @@ Path to deploy hook script.
 Data type: `Variant[String[1],Array[String[1]]]`
 
 Bash commands to execute when the hook is run by certbot.
+
+### <a name="letsencrypt--profile"></a>`letsencrypt::profile`
+
+Defines a Let's Encrypt profile.
+
+#### Parameters
+
+The following parameters are available in the `letsencrypt::profile` defined type:
+
+* [`config`](#-letsencrypt--profile--config)
+* [`config_file`](#-letsencrypt--profile--config_file)
+
+##### <a name="-letsencrypt--profile--config"></a>`config`
+
+Data type: `Hash`
+
+A hash of configuration options for the profile.
+
+Default value: `{}`
+
+##### <a name="-letsencrypt--profile--config_file"></a>`config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Optional explicit path to the ini file. Defaults to `${config_dir}/${name}.ini`.
+
+Default value: `"${letsencrypt::config_dir}/${name}.ini"`
 
 ## Functions
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -121,9 +121,10 @@
 #                       Example: "example.com www.example.com"
 #
 # @param cert_name the common name used for the certificate
-#
+# @param profile an optional profile to use for this certificate. If not specified, the default CLI profile will be used.
 define letsencrypt::certonly (
   Enum['present','absent']                  $ensure               = 'present',
+  String[1]                                 $profile              = 'cli',
   Array[String[1]]                          $domains              = [$title],
   String[1]                                 $cert_name            = $domains[0],
   Boolean                                   $custom_plugin        = false,
@@ -150,8 +151,18 @@ define letsencrypt::certonly (
   if $plugin == 'webroot' and empty($webroot_paths) {
     fail("The 'webroot_paths' parameter must be specified when using the 'webroot' plugin")
   }
+  if !defined(Letsencrypt::Profile[$profile]) {
+    fail("The '${profile}' letsencrypt::profile must be defined")
+  }
 
   include letsencrypt::scripts
+
+  $config_file = getparam(Letsencrypt::Profile[$profile], 'config_file')
+  # We dont pass --config when profile is cli to maintain backwards compatability
+  $config_arg = $profile ? {
+    'cli' => undef,
+    default => "--config ${config_file}",
+  }
 
   # Wildcard-less title for use in file paths
   $title_nowc = regsubst($title, '^\*\.', '')
@@ -296,6 +307,7 @@ define letsencrypt::certonly (
     [
       $letsencrypt_command,
       $default_args,
+      $config_arg,
       $plugin_args,
       $hook_args,
       $additional_args,
@@ -321,6 +333,7 @@ define letsencrypt::certonly (
     provider    => 'shell',
     require     => [
       File['/usr/local/sbin/letsencrypt-domain-validation'],
+      Letsencrypt::Profile[$profile],
     ],
   }
   # lint:endignore

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@
 # @api private
 #
 class letsencrypt::config (
+  # TODO: as this is a private class, we can remove the parameters and define the variables in the class body.
   Stdlib::Absolutepath $config_dir = $letsencrypt::config_dir,
   Stdlib::Absolutepath $config_file = $letsencrypt::config_file,
   Hash $config = $letsencrypt::config,
@@ -16,43 +17,11 @@ class letsencrypt::config (
     fail("You must agree to the Let's Encrypt Terms of Service! See: https://letsencrypt.org/repository for more information." )
   }
 
-  file { $config_dir: ensure => directory }
+  ensure_resource('file', $config_dir, { ensure => directory })
 
-  file { $letsencrypt::cron_scripts_path:
-    ensure => directory,
-    purge  => true,
-  }
-
-  if $email {
-    $_config = $config + { 'email' => $email }
-  } else {
-    $_config = $config
-  }
-
-  ini_setting { "${config_file} register-unsafely-without-email true":
-    ensure  => bool2str($unsafe_registration, 'present', 'absent'),
-    path    => $config_file,
-    section => '',
-    setting => 'register-unsafely-without-email',
-    value   => true,
-  }
-
-  unless 'email' in $_config {
-    if $unsafe_registration {
-      warning('No email address specified for the letsencrypt class! Registering unsafely!')
-    } else {
-      fail("Please specify an email address to register with Let's Encrypt using the \$email parameter on the letsencrypt class")
-    }
-  }
-
-  $_config.each |$key,$value| {
-    ini_setting { "${config_file} ${key} ${value}":
-      ensure  => present,
-      path    => $config_file,
-      section => '',
-      setting => $key,
-      value   => $value,
-      require => File[$config_dir],
-    }
+  $_config = $config + { 'email' => $email, 'register-unsafely-without-email' => $unsafe_registration }.filter |$k, $v| { $v }
+  letsencrypt::profile { 'cli':
+    config      => $_config,
+    config_file => $config_file,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@
 # @param package_command Path or name for letsencrypt executable.
 # @param config_file The path to the configuration file for the letsencrypt cli.
 # @param config A hash representation of the letsencrypt configuration file.
+# @param profiles A hash of profiles. Each key is the title and each value is a hash, both passed to letsencrypt::profile.
 # @param cron_scripts_path The path for renewal scripts called by cron
 # @param cron_owner_group Group owner of cron renew scripts.
 # @param manage_config A feature flag to toggle the management of the letsencrypt configuration file.
@@ -76,6 +77,7 @@ class letsencrypt (
   Stdlib::Unixpath $config_dir       = '/etc/letsencrypt',
   String $config_file                = "${config_dir}/cli.ini",
   Hash $config                       = { 'server' => 'https://acme-v02.api.letsencrypt.org/directory' },
+  Hash $profiles                     = {},
   String $cron_scripts_path          = "${facts['puppet_vardir']}/letsencrypt",
   String $cron_owner_group           = 'root',
   Boolean $manage_config             = true,
@@ -110,7 +112,13 @@ class letsencrypt (
   $command = $package_command
 
   if $manage_config {
+    if 'cli' in $profiles.keys {
+      fail("The profile title 'cli' is reserved and managed by letsencrypt::config. Please use the class parameters 'config' and 'email' instead of defining profiles['cli'].")
+    }
     contain letsencrypt::config # lint:ignore:relative_classname_inclusion
+  }
+  $profiles.each |$profile, $properties| {
+    letsencrypt::profile { $profile: * => $properties }
   }
 
   contain letsencrypt::renew

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@
 # @api private
 #
 class letsencrypt::install (
+  # TODO: as this is a private class, we can remove the parameters and define the variables in the class body.
   Boolean $configure_epel = $letsencrypt::configure_epel,
   String $package_name = $letsencrypt::package_name,
   String $package_ensure = $letsencrypt::package_ensure,
@@ -16,6 +17,14 @@ class letsencrypt::install (
   package { 'letsencrypt':
     ensure => $package_ensure,
     name   => $package_name,
+    before => File[$letsencrypt::cron_scripts_path, $letsencrypt::config_dir],
+  }
+
+  ensure_resource('file', $letsencrypt::config_dir, { ensure => directory })
+
+  file { $letsencrypt::cron_scripts_path:
+    ensure => directory,
+    purge  => $letsencrypt::manage_config,
   }
 
   if $configure_epel {

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -1,0 +1,28 @@
+# @summary Defines a Let's Encrypt profile.
+# @param config A hash of configuration options for the profile.
+# @param config_file Optional explicit path to the ini file. Defaults to `${config_dir}/${name}.ini`.
+define letsencrypt::profile (
+  Hash                 $config = {},
+  Stdlib::Absolutepath $config_file = "${letsencrypt::config_dir}/${name}.ini",
+) {
+  include letsencrypt
+
+  unless 'email' in $config {
+    if 'register-unsafely-without-email' in $config {
+      warning("Profile ${name}: No email address specified for the letsencrypt class! Registering unsafely!")
+    } else {
+      fail("Profile ${name}: Please specify an email address to register with Let's Encrypt")
+    }
+  }
+
+  $config.each |$key,$value| {
+    ini_setting { "${config_file} ${key} ${value}":
+      ensure  => present,
+      path    => $config_file,
+      section => '',
+      setting => $key,
+      value   => $value,
+      require => File[$letsencrypt::config_dir],
+    }
+  }
+}

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -107,6 +107,17 @@ describe 'letsencrypt' do
           end
         end
 
+        describe 'with custom profile' do
+          let(:additional_params) { { profiles: { 'foo' => { 'config' => { 'email' => 'foo@example.com' } } } } }
+
+          case facts['os']['name']
+          when 'FreeBSD'
+            it { is_expected.to contain_ini_setting('/usr/local/etc/letsencrypt/foo.ini email foo@example.com') }
+          else
+            it { is_expected.to contain_ini_setting('/etc/letsencrypt/foo.ini email foo@example.com') }
+          end
+        end
+
         describe 'with manage_config set to false' do
           let(:additional_params) { { manage_config: false } }
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -575,6 +575,26 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_ini_setting('foo.example.com-deploy') }
         it { is_expected.to have_letsencrypt__hook_resource_count(3) }
       end
+
+      context 'with custom profile' do
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'letsencrypt':
+            manage_config => false,
+            profiles => {
+              'custom' => { 'config' => { 'email' => 'foo@example.com' } }
+            },
+          }
+          PUPPET
+        end
+        let(:title) { 'foo.example.com' }
+        let(:params) { { manage_cron: true, profile: 'custom' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "certbot --text --agree-tos --non-interactive certonly --key-type rsa --rsa-key-size 4096 -a standalone --config #{pathprefix}/etc/letsencrypt/custom.ini --cert-name 'foo.example.com' -d 'foo.example.com'" }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command('"/var/lib/puppet/letsencrypt/renew-foo.example.com.sh"').with_ensure('present') }
+        it { is_expected.to contain_file('/var/lib/puppet/letsencrypt/renew-foo.example.com.sh').with_ensure('file').with_content("#!/bin/sh\ncertbot --keep-until-expiring --text --agree-tos --non-interactive certonly --key-type rsa --rsa-key-size 4096 -a standalone --config #{pathprefix}/etc/letsencrypt/custom.ini --cert-name 'foo.example.com' -d 'foo.example.com'\n") }
+      end
     end
   end
 end

--- a/spec/defines/letsencrypt_profile_spec.rb
+++ b/spec/defines/letsencrypt_profile_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'letsencrypt::profile' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      let(:title) { 'staging' }
+      let(:letsencrypt_config_dir) do
+        (facts['os']['family'] == 'FreeBSD') ? '/usr/local/etc/letsencrypt' : '/etc/letsencrypt'
+      end
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'letsencrypt':
+          email         => 'spec@example.com',
+        }
+        PUPPET
+      end
+
+      context 'with valid config' do
+        let(:params) do
+          {
+            config: {
+              'email' => 'foo@example.com',
+              'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_ini_setting("#{letsencrypt_config_dir}/staging.ini email foo@example.com") }
+        it { is_expected.to contain_ini_setting("#{letsencrypt_config_dir}/staging.ini server https://acme-staging-v02.api.letsencrypt.org/directory") }
+      end
+
+      context 'with custom config_file' do
+        let(:params) do
+          {
+            config_file: '/tmp/staging.ini',
+            config: {
+              'email' => 'foo@example.com',
+              'server' => 'https://acme-staging-v02.api.letsencrypt.org/directory',
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_ini_setting('/tmp/staging.ini email foo@example.com') }
+        it { is_expected.to contain_ini_setting('/tmp/staging.ini server https://acme-staging-v02.api.letsencrypt.org/directory') }
+      end
+
+      context 'without email and unsafe_registration disabled' do
+        let(:params) do
+          {
+            config: {
+              'server' => 'https://acme-v02.api.letsencrypt.org/directory',
+            },
+          }
+        end
+
+        it { is_expected.to raise_error(Puppet::Error, %r{Profile staging: Please specify an email address to register with Let's Encrypt}) }
+      end
+
+      context 'without email and with unsafe registration' do
+        let(:params) do
+          {
+            config: {
+              'server' => 'https://acme-v02.api.letsencrypt.org/directory',
+              'register-unsafely-without-email' => true,
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_ini_setting("#{letsencrypt_config_dir}/staging.ini register-unsafely-without-email true") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow users to install multiple profiles.  This allows one to test against e.g. the staging and production letsencypt environments. however more importantly it allows to use certbot with other amce enabled CA's such as sectigo.

I have tried to make this backwards compatible but there may be some edge cases i have missed so perhaps worth a major bump if accepted 